### PR TITLE
refactor/ft_printf

### DIFF
--- a/include/libft.h
+++ b/include/libft.h
@@ -68,6 +68,7 @@ void	ft_lstadd_back(t_list **lst, t_list *node);
 void	ft_lstdelone(t_list *lst, void (*del)(void *));
 void	ft_lstclear(t_list **lst, void (*del)(void *));
 int		ft_dprintf(int fd, const char *s, ...);
+int		ft_printf(const char *s, ...);
 int		ft_vdprintf(int fd, const char *s, va_list ap);
 char	*get_next_line(int fd);
 

--- a/include/libft.h
+++ b/include/libft.h
@@ -67,6 +67,7 @@ int		ft_lstsize(t_list *lst);
 void	ft_lstadd_back(t_list **lst, t_list *node);
 void	ft_lstdelone(t_list *lst, void (*del)(void *));
 void	ft_lstclear(t_list **lst, void (*del)(void *));
+int		ft_dprintf(int fd, const char *s, ...);
 int		ft_vdprintf(int fd, const char *s, va_list ap);
 char	*get_next_line(int fd);
 

--- a/include/libft.h
+++ b/include/libft.h
@@ -13,6 +13,7 @@
 #ifndef LIBFT_H
 # define LIBFT_H
 
+# include <stdarg.h>
 # include <stddef.h>
 
 # define BUFFER_SIZE 42
@@ -66,7 +67,7 @@ int		ft_lstsize(t_list *lst);
 void	ft_lstadd_back(t_list **lst, t_list *node);
 void	ft_lstdelone(t_list *lst, void (*del)(void *));
 void	ft_lstclear(t_list **lst, void (*del)(void *));
-int		ft_printf(const char *s, ...);
+int		ft_vdprintf(int fd, const char *s, va_list ap);
 char	*get_next_line(int fd);
 
 #endif

--- a/lib/libft/Makefile
+++ b/lib/libft/Makefile
@@ -49,7 +49,7 @@ SRC = ft_strnstr.c \
 	  ft_lstclear.c \
 	  ft_printf/parse_int.c \
 	  ft_printf/parse_char.c \
-	  ft_printf/ft_printf.c \
+	  ft_printf/ft_vdprintf.c \
 	  ft_printf/parse_unsigned_hex.c \
 	  ft_printf/parse_unsigned_int.c \
 	  ft_printf/parse_str.c \

--- a/lib/libft/Makefile
+++ b/lib/libft/Makefile
@@ -50,6 +50,7 @@ SRC = ft_strnstr.c \
 	  ft_printf/parse_int.c \
 	  ft_printf/parse_char.c \
 	  ft_printf/ft_dprintf.c \
+	  ft_printf/ft_printf.c \
 	  ft_printf/ft_vdprintf.c \
 	  ft_printf/parse_unsigned_hex.c \
 	  ft_printf/parse_unsigned_int.c \

--- a/lib/libft/Makefile
+++ b/lib/libft/Makefile
@@ -49,6 +49,7 @@ SRC = ft_strnstr.c \
 	  ft_lstclear.c \
 	  ft_printf/parse_int.c \
 	  ft_printf/parse_char.c \
+	  ft_printf/ft_dprintf.c \
 	  ft_printf/ft_vdprintf.c \
 	  ft_printf/parse_unsigned_hex.c \
 	  ft_printf/parse_unsigned_int.c \

--- a/lib/libft/ft_printf/ft_dprintf.c
+++ b/lib/libft/ft_printf/ft_dprintf.c
@@ -1,0 +1,25 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_dprintf.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: weizhang <weiqi.zhang_arthur@yahoo.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/04/16 22:26:02 by weizhang          #+#    #+#             */
+/*   Updated: 2026/04/16 22:27:34 by weizhang         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <stdarg.h>
+#include "libft.h"
+
+int	ft_dprintf(int fd, const char *s, ...)
+{
+	va_list	ap;
+	int		ret;
+
+	va_start(ap, s);
+	ret = ft_vdprintf(fd, s, ap);
+	va_end(ap);
+	return (ret);
+}

--- a/lib/libft/ft_printf/ft_printf.c
+++ b/lib/libft/ft_printf/ft_printf.c
@@ -1,0 +1,26 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_printf.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: weizhang <weiqi.zhang_arthur@yahoo.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/04/16 22:36:47 by weizhang          #+#    #+#             */
+/*   Updated: 2026/04/16 22:37:28 by weizhang         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <unistd.h>
+#include <stdarg.h>
+#include "libft.h"
+
+int	ft_printf(const char *s, ...)
+{
+	va_list	ap;
+	int		ret;
+
+	va_start(ap, s);
+	ret = ft_vdprintf(STDOUT_FILENO, s, ap);
+	va_end(ap);
+	return (ret);
+}

--- a/lib/libft/ft_printf/ft_vdprintf.c
+++ b/lib/libft/ft_printf/ft_vdprintf.c
@@ -14,37 +14,30 @@
 #include <stdarg.h>
 #include "libft.h"
 
-int	parse_arg(char placeholder, va_list *list);
+int	parse_arg(int fd, char placeholder, va_list *list);
 
-static int	norminette(const char *s, va_list *args_ptr, size_t i, int count)
+int	ft_vdprintf(int fd, const char *s, va_list ap)
 {
-	int	substr_count;
+	size_t	i;
+	int		count;
+	int		substr_count;
 
+	i = 0;
+	count = 0;
 	while (s[i])
 	{
 		if (s[i] == '%')
 		{
-			substr_count = parse_arg(s[i + 1], args_ptr);
+			substr_count = parse_arg(fd, s[i + 1], &ap);
 			if (substr_count < 0)
 				return (-1);
 			count += substr_count;
 			i += 2;
 			continue ;
 		}
-		ft_putchar_fd(s[i], 1);
+		ft_putchar_fd(s[i], fd);
 		i++;
 		count++;
 	}
-	return (count);
-}
-
-int	ft_printf(const char *s, ...)
-{
-	int		count;
-	va_list	args;
-
-	va_start(args, s);
-	count = norminette(s, &args, 0, 0);
-	va_end(args);
 	return (count);
 }

--- a/lib/libft/ft_printf/parse_char.c
+++ b/lib/libft/ft_printf/parse_char.c
@@ -12,8 +12,8 @@
 
 #include "libft.h"
 
-int	parse_char(char a)
+int	parse_char(int fd, char a)
 {
-	ft_putchar_fd(a, 1);
+	ft_putchar_fd(a, fd);
 	return (1);
 }

--- a/lib/libft/ft_printf/parse_int.c
+++ b/lib/libft/ft_printf/parse_int.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include "libft.h"
 
-int	parse_int(int nbr)
+int	parse_int(int fd, int nbr)
 {
 	char	*nbr_str;
 	int		nbr_len;
@@ -21,7 +21,7 @@ int	parse_int(int nbr)
 	nbr_str = ft_itoa(nbr);
 	if (!nbr_str)
 		return (-1);
-	ft_putstr_fd(nbr_str, 1);
+	ft_putstr_fd(nbr_str, fd);
 	nbr_len = ft_strlen(nbr_str);
 	free(nbr_str);
 	return (nbr_len);

--- a/lib/libft/ft_printf/parse_pointer.c
+++ b/lib/libft/ft_printf/parse_pointer.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include "libft.h"
 
-int	parse_str(char *s);
+int	parse_str(int fd, char *s);
 
 static int	ft_numlen_base(unsigned long n, int base)
 {
@@ -52,19 +52,19 @@ static char	*ptr_to_hex(unsigned long n)
 	return (num_str);
 }
 
-int	parse_pointer(void *ptr)
+int	parse_pointer(int fd, void *ptr)
 {
 	unsigned long	ptr_value;
 	char			*ptr_hex_str;
 	size_t			ptr_hex_str_len;
 
 	if (!ptr)
-		return (parse_str("(nil)"));
+		return (parse_str(fd, "(nil)"));
 	ptr_value = (unsigned long)ptr;
 	ptr_hex_str = ptr_to_hex(ptr_value);
 	if (!ptr_hex_str)
 		return (-1);
-	ft_putstr_fd(ptr_hex_str, 1);
+	ft_putstr_fd(ptr_hex_str, fd);
 	ptr_hex_str_len = ft_strlen(ptr_hex_str);
 	free(ptr_hex_str);
 	return (ptr_hex_str_len);

--- a/lib/libft/ft_printf/parse_str.c
+++ b/lib/libft/ft_printf/parse_str.c
@@ -12,13 +12,13 @@
 
 #include "libft.h"
 
-int	parse_str(char *s)
+int	parse_str(int fd, char *s)
 {
 	if (!s)
 	{
-		ft_putstr_fd("(null)", 1);
+		ft_putstr_fd("(null)", fd);
 		return (ft_strlen("(null)"));
 	}
-	ft_putstr_fd(s, 1);
+	ft_putstr_fd(s, fd);
 	return (ft_strlen(s));
 }

--- a/lib/libft/ft_printf/parse_unsigned_hex.c
+++ b/lib/libft/ft_printf/parse_unsigned_hex.c
@@ -64,14 +64,14 @@ static char	*itohexa(unsigned int n, bool upper)
 	return (hexa);
 }
 
-int	parse_unsigned_hex(unsigned int n, bool upper)
+int	parse_unsigned_hex(int fd, unsigned int n, bool upper)
 {
 	char	*hexa;
 	int		len;
 
 	hexa = itohexa(n, upper);
 	len = ft_strlen(hexa);
-	ft_putstr_fd(hexa, 1);
+	ft_putstr_fd(hexa, fd);
 	free(hexa);
 	return (len);
 }

--- a/lib/libft/ft_printf/parse_unsigned_int.c
+++ b/lib/libft/ft_printf/parse_unsigned_int.c
@@ -13,7 +13,7 @@
 #include <unistd.h>
 #include "libft.h"
 
-int	parse_unsigned_int(unsigned int n)
+int	parse_unsigned_int(int fd, unsigned int n)
 {
 	int		count;
 
@@ -21,10 +21,10 @@ int	parse_unsigned_int(unsigned int n)
 	if (n < 10)
 	{
 		n += '0';
-		write(1, &n, 1);
+		write(fd, &n, 1);
 		return (1);
 	}
-	count += parse_unsigned_int(n / 10);
-	count += parse_unsigned_int(n % 10);
+	count += parse_unsigned_int(fd, n / 10);
+	count += parse_unsigned_int(fd, n % 10);
 	return (count);
 }

--- a/lib/libft/ft_printf/parser.c
+++ b/lib/libft/ft_printf/parser.c
@@ -14,32 +14,32 @@
 #include <stdbool.h>
 #include "libft.h"
 
-int	parse_char(char a);
-int	parse_str(char *s);
-int	parse_int(int n);
-int	parse_pointer(void *ptr);
-int	parse_unsigned_int(unsigned int n);
-int	parse_unsigned_hex(unsigned int n, bool upper);
+int	parse_char(int fd, char a);
+int	parse_str(int fd, char *s);
+int	parse_int(int fd, int n);
+int	parse_pointer(int fd, void *ptr);
+int	parse_unsigned_int(int fd, unsigned int n);
+int	parse_unsigned_hex(int fd, unsigned int n, bool upper);
 
-int	parse_arg(char arg, va_list *args)
+int	parse_arg(int fd, char arg, va_list *args)
 {
 	if (arg == 'c')
-		return (parse_char(va_arg(*args, int)));
+		return (parse_char(fd, va_arg(*args, int)));
 	if (arg == 's')
-		return (parse_str(va_arg(*args, char *)));
+		return (parse_str(fd, va_arg(*args, char *)));
 	if (arg == 'p')
-		return (parse_pointer(va_arg(*args, void *)));
+		return (parse_pointer(fd, va_arg(*args, void *)));
 	if (arg == 'd' || arg == 'i')
-		return (parse_int(va_arg(*args, int)));
+		return (parse_int(fd, va_arg(*args, int)));
 	if (arg == 'u')
-		return (parse_unsigned_int(va_arg(*args, unsigned int)));
+		return (parse_unsigned_int(fd, va_arg(*args, unsigned int)));
 	if (arg == 'x')
-		return (parse_unsigned_hex(va_arg(*args, unsigned int), false));
+		return (parse_unsigned_hex(fd, va_arg(*args, unsigned int), false));
 	if (arg == 'X')
-		return (parse_unsigned_hex(va_arg(*args, unsigned int), true));
+		return (parse_unsigned_hex(fd, va_arg(*args, unsigned int), true));
 	if (arg == '%')
 	{
-		ft_putchar_fd('%', 1);
+		ft_putchar_fd('%', fd);
 		return (1);
 	}
 	return (-1);


### PR DESCRIPTION
- Refactor `ft_printf` into a layered API: `ft_vdprintf` (core), `ft_dprintf` (variadic + fd), and `ft_printf` (thin wrapper writing to stdout).
- This is needed as `ft_dprintf` allows us to printf to STDERR_FILENO for the upcoming error handling functionalities.
- Functions are named according to POSIX.1-2008 C standard