### PR TITLE
fix: make ft_vdprintf compatible for mac and linux

### DIFF
--- a/lib/libft/ft_printf/ft_vdprintf.c
+++ b/lib/libft/ft_printf/ft_vdprintf.c
@@ -14,7 +14,7 @@
 #include <stdarg.h>
 #include "libft.h"
 
-int	parse_arg(int fd, char placeholder, va_list *list);
+int	parse_arg(int fd, char placeholder, va_list ap);
 
 int	ft_vdprintf(int fd, const char *s, va_list ap)
 {
@@ -28,7 +28,7 @@ int	ft_vdprintf(int fd, const char *s, va_list ap)
 	{
 		if (s[i] == '%')
 		{
-			substr_count = parse_arg(fd, s[i + 1], &ap);
+			substr_count = parse_arg(fd, s[i + 1], ap);
 			if (substr_count < 0)
 				return (-1);
 			count += substr_count;

--- a/lib/libft/ft_printf/parser.c
+++ b/lib/libft/ft_printf/parser.c
@@ -21,22 +21,22 @@ int	parse_pointer(int fd, void *ptr);
 int	parse_unsigned_int(int fd, unsigned int n);
 int	parse_unsigned_hex(int fd, unsigned int n, bool upper);
 
-int	parse_arg(int fd, char arg, va_list *args)
+int	parse_arg(int fd, char arg, va_list args)
 {
 	if (arg == 'c')
-		return (parse_char(fd, va_arg(*args, int)));
+		return (parse_char(fd, va_arg(args, int)));
 	if (arg == 's')
-		return (parse_str(fd, va_arg(*args, char *)));
+		return (parse_str(fd, va_arg(args, char *)));
 	if (arg == 'p')
-		return (parse_pointer(fd, va_arg(*args, void *)));
+		return (parse_pointer(fd, va_arg(args, void *)));
 	if (arg == 'd' || arg == 'i')
-		return (parse_int(fd, va_arg(*args, int)));
+		return (parse_int(fd, va_arg(args, int)));
 	if (arg == 'u')
-		return (parse_unsigned_int(fd, va_arg(*args, unsigned int)));
+		return (parse_unsigned_int(fd, va_arg(args, unsigned int)));
 	if (arg == 'x')
-		return (parse_unsigned_hex(fd, va_arg(*args, unsigned int), false));
+		return (parse_unsigned_hex(fd, va_arg(args, unsigned int), false));
 	if (arg == 'X')
-		return (parse_unsigned_hex(fd, va_arg(*args, unsigned int), true));
+		return (parse_unsigned_hex(fd, va_arg(args, unsigned int), true));
 	if (arg == '%')
 	{
 		ft_putchar_fd('%', fd);


### PR DESCRIPTION
`va_list` has different behavior when passed by reference. Passing by value solves the issue