### PR TITLE
Builtin/pwd claude

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ SRC = ./src/checker.c \
 	  ./src/parser.c \
 	  ./src/redir.c \
 	  ./src/token.c \
+	  ./src/builtins/env.c \
 	  ./src/utils/gc_execvp.c \
 	  ./src/utils/gc_getcwd.c \
 	  ./src/utils/gc_readline.c \

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SRC = ./src/checker.c \
 	  ./src/redir.c \
 	  ./src/token.c \
 	  ./src/builtins/env.c \
+	  ./src/builtins/pwd.c \
 	  ./src/utils/gc_execvp.c \
 	  ./src/utils/gc_getcwd.c \
 	  ./src/utils/gc_readline.c \

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ SRC = ./src/checker.c \
 	  ./src/utils/gc_execvp.c \
 	  ./src/utils/gc_getcwd.c \
 	  ./src/utils/gc_readline.c \
+	  ./src/utils/str_utils.c \
 	  ./src/utils/utils.c
 
 OBJ = $(SRC:.c=.o)

--- a/include/datastructures.h
+++ b/include/datastructures.h
@@ -42,6 +42,7 @@ struct s_darray
 			void *(*f)(void *i1, void *i2, t_gc *gc), void *a);
 };
 t_darray	*init_darray(t_gc *gc);
+t_darray	*init_from_arr(void **arr, t_gc *gc);
 
 typedef struct s_btree	t_btree;
 struct s_btree

--- a/include/datastructures.h
+++ b/include/datastructures.h
@@ -6,7 +6,7 @@
 /*   By: weiqizhang <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/01/23 12:58:22 by weiqizhang        #+#    #+#             */
-/*   Updated: 2026/03/17 17:47:20 by weizhang         ###   ########.fr       */
+/*   Updated: 2026/04/30 23:52:34 by weizhang         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -36,6 +36,7 @@ struct s_darray
 	void	(*push)(t_darray *self, void *item);
 	void	*(*pop_i)(t_darray *self, size_t i);
 	void	*(*pop)(t_darray *self);
+	bool	(*any)(t_darray * self, bool (*f)(void *, void *), void *target);
 	void	*(*reduce)(t_darray *s,
 			void *(*f)(void *i1, void *i2, t_gc *gc), void *a);
 };

--- a/include/datastructures.h
+++ b/include/datastructures.h
@@ -37,6 +37,7 @@ struct s_darray
 	void	*(*pop_i)(t_darray *self, size_t i);
 	void	*(*pop)(t_darray *self);
 	bool	(*any)(t_darray * self, bool (*f)(void *, void *), void *target);
+	void	*(*find)(t_darray *s, bool (*f)(void *e1, void *e2), void *e2);
 	void	*(*reduce)(t_darray *s,
 			void *(*f)(void *i1, void *i2, t_gc *gc), void *a);
 };

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -90,7 +90,7 @@ t_env		*init_env(t_gc *gc);
 int			gc_execvp(const char *cmd, char *const argv[], t_gc *gc);
 char		*gc_readline(const char *prompt, t_gc *gc);
 char		*gc_getcwd(t_gc *gc);
-t_btree		*parse(char *input, t_gc *gc);
+t_btree		*parse(char *input, t_env *env);
 int			execute(t_btree *ast);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -78,6 +78,15 @@ struct s_token
 t_token		*init_token(char *value, t_gc *gc);
 t_token		*init_cmd_token(t_cmd *cmd, t_gc *gc);
 
+typedef struct s_env
+{
+	int			exit_code;
+	t_darray	*builtins;
+	t_darray	*envp;
+	t_gc		*gc;
+}	t_env;
+t_env		*init_env(t_gc *gc);
+
 int			gc_execvp(const char *cmd, char *const argv[], t_gc *gc);
 char		*gc_readline(const char *prompt, t_gc *gc);
 char		*gc_getcwd(t_gc *gc);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -78,6 +78,7 @@ struct s_token
 t_token		*init_token(char *value, t_gc *gc);
 t_token		*init_cmd_token(t_cmd *cmd, t_gc *gc);
 
+int			gc_execvp(const char *cmd, char *const argv[], t_gc *gc);
 char		*gc_readline(const char *prompt, t_gc *gc);
 char		*gc_getcwd(t_gc *gc);
 t_btree		*parse(char *input, t_gc *gc);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -91,6 +91,6 @@ int			gc_execvp(const char *cmd, char *const argv[], t_gc *gc);
 char		*gc_readline(const char *prompt, t_gc *gc);
 char		*gc_getcwd(t_gc *gc);
 t_btree		*parse(char *input, t_env *env);
-int			execute(t_btree *ast, t_env *env);
+void		execute(t_btree *ast, t_env *env);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -87,7 +87,8 @@ typedef struct s_env
 }	t_env;
 t_env		*init_env(t_gc *gc);
 
-int			gc_execvp(const char *cmd, char *const argv[], t_gc *gc);
+int			gc_execvp(const char *cmd, char *const argv[],
+				char **envp, t_gc *gc);
 char		*gc_readline(const char *prompt, t_gc *gc);
 char		*gc_getcwd(t_gc *gc);
 t_btree		*parse(char *input, t_env *env);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -91,6 +91,6 @@ int			gc_execvp(const char *cmd, char *const argv[], t_gc *gc);
 char		*gc_readline(const char *prompt, t_gc *gc);
 char		*gc_getcwd(t_gc *gc);
 t_btree		*parse(char *input, t_env *env);
-int			execute(t_btree *ast);
+int			execute(t_btree *ast, t_env *env);
 
 #endif

--- a/lib/datastructures/darray_basic.c
+++ b/lib/datastructures/darray_basic.c
@@ -6,7 +6,7 @@
 /*   By: weiqizhang <marvin@42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/01/23 00:08:35 by weiqizhang        #+#    #+#             */
-/*   Updated: 2026/03/24 19:46:09 by weizhang         ###   ########.fr       */
+/*   Updated: 2026/04/30 23:55:41 by weizhang         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,7 @@ void	insert(t_darray *self, size_t i, void *item);
 void	push(t_darray *self, void *item);
 void	*pop_i(t_darray *self, size_t i);
 void	*pop(t_darray *self);
+bool	any(t_darray *s, bool (*f)(void *elem, void *target), void *target);
 void	*reduce(t_darray *s, void *(*f)(void *i1, void *i2, t_gc *gc), void *a);
 
 static void	**to_arr(t_darray *self)
@@ -76,6 +77,7 @@ t_darray	*init_darray(t_gc *gc)
 	darray->push = push;
 	darray->pop_i = pop_i;
 	darray->pop = pop;
+	darray->any = any;
 	darray->reduce = reduce;
 	return (darray);
 }

--- a/lib/datastructures/darray_basic.c
+++ b/lib/datastructures/darray_basic.c
@@ -22,6 +22,7 @@ void	push(t_darray *self, void *item);
 void	*pop_i(t_darray *self, size_t i);
 void	*pop(t_darray *self);
 bool	any(t_darray *s, bool (*f)(void *elem, void *target), void *target);
+void	*find(t_darray *s, bool (*f)(void *e1, void *e2), void *e2);
 void	*reduce(t_darray *s, void *(*f)(void *i1, void *i2, t_gc *gc), void *a);
 
 static void	**to_arr(t_darray *self)
@@ -78,6 +79,7 @@ t_darray	*init_darray(t_gc *gc)
 	darray->pop_i = pop_i;
 	darray->pop = pop;
 	darray->any = any;
+	darray->find = find;
 	darray->reduce = reduce;
 	return (darray);
 }

--- a/lib/datastructures/darray_basic.c
+++ b/lib/datastructures/darray_basic.c
@@ -83,3 +83,18 @@ t_darray	*init_darray(t_gc *gc)
 	darray->reduce = reduce;
 	return (darray);
 }
+
+t_darray	*init_from_arr(void **arr, t_gc *gc)
+{
+	t_darray	*darray;
+	size_t		i;
+
+	darray = init_darray(gc);
+	i = 0;
+	while (arr[i])
+	{
+		darray->push(darray, arr[i]);
+		i++;
+	}
+	return (darray);
+}

--- a/lib/datastructures/darray_functional.c
+++ b/lib/datastructures/darray_functional.c
@@ -6,11 +6,27 @@
 /*   By: weizhang <weiqi.zhang_arthur@yahoo.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/02 01:21:10 by weizhang          #+#    #+#             */
-/*   Updated: 2026/04/02 01:24:54 by weizhang         ###   ########.fr       */
+/*   Updated: 2026/04/30 23:54:38 by weizhang         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stddef.h>
+#include <stdbool.h>
 #include "datastructures.h"
+
+bool	any(t_darray *s, bool (*f)(void *elem, void *target), void *target)
+{
+	size_t	i;
+
+	i = 0;
+	while (i < s->len)
+	{
+		if (f(s->peek_i(s, i), target))
+			return (true);
+		i++;
+	}
+	return (false);
+}
 
 void	*reduce(t_darray *s, void *(*f)(void *i1, void *i2, t_gc *gc), void *a)
 {

--- a/lib/datastructures/darray_functional.c
+++ b/lib/datastructures/darray_functional.c
@@ -28,6 +28,20 @@ bool	any(t_darray *s, bool (*f)(void *elem, void *target), void *target)
 	return (false);
 }
 
+void	*find(t_darray *s, bool (*f)(void *e1, void *e2), void *e2)
+{
+	size_t	i;
+
+	i = 0;
+	while (i < s->len)
+	{
+		if (f(s->peek_i(s, i), e2))
+			return (s->peek_i(s, i));
+		i++;
+	}
+	return (NULL);
+}
+
 void	*reduce(t_darray *s, void *(*f)(void *i1, void *i2, t_gc *gc), void *a)
 {
 	size_t	i;

--- a/src/builtins/env.c
+++ b/src/builtins/env.c
@@ -1,0 +1,28 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   env.c                                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: weizhang <weiqi.zhang_arthur@yahoo.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/04/28 23:40:06 by weizhang          #+#    #+#             */
+/*   Updated: 2026/04/30 21:18:58 by weizhang         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "datastructures.h"
+#include "gc_libft.h"
+#include "minishell.h"
+
+t_env	*init_env(t_gc *gc)
+{
+	t_env		*env;
+	extern char	**environ;
+
+	env = gc_malloc(sizeof(t_env), gc);
+	env->exit_code = 0;
+	env->builtins = NULL;
+	env->envp = init_from_arr((void **)environ, gc);
+	env->gc = gc;
+	return (env);
+}

--- a/src/builtins/env.c
+++ b/src/builtins/env.c
@@ -14,6 +14,23 @@
 #include "gc_libft.h"
 #include "minishell.h"
 
+void	pwd(char **options, t_env *env);
+
+void	exec_builtins(char *cmd, char **options, t_env *env)
+{
+	if (ft_strcmp(cmd, "pwd") == 0)
+		pwd(options, env);
+}
+
+t_darray	*init_builtins(t_gc *gc)
+{
+	t_darray	*builtins;
+
+	builtins = init_darray(gc);
+	builtins->push(builtins, ft_strdup("pwd"));
+	return (builtins);
+}
+
 t_env	*init_env(t_gc *gc)
 {
 	t_env		*env;
@@ -21,7 +38,7 @@ t_env	*init_env(t_gc *gc)
 
 	env = gc_malloc(sizeof(t_env), gc);
 	env->exit_code = 0;
-	env->builtins = NULL;
+	env->builtins = init_builtins(gc);
 	env->envp = init_from_arr((void **)environ, gc);
 	env->gc = gc;
 	return (env);

--- a/src/builtins/pwd.c
+++ b/src/builtins/pwd.c
@@ -1,0 +1,21 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   pwd.c                                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: weizhang <weiqi.zhang_arthur@yahoo.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/04/30 21:10:30 by weizhang          #+#    #+#             */
+/*   Updated: 2026/04/30 21:12:24 by weizhang         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <stdio.h>
+#include "minishell.h"
+
+void	pwd(char **options, t_env *env)
+{
+	(void)(options);
+	printf("%s\n", gc_getcwd(env->gc));
+	env->exit_code = 0;
+}

--- a/src/checker.c
+++ b/src/checker.c
@@ -13,10 +13,11 @@
 #include "minishell.h"
 
 t_lexer_state	update_state(char c, t_lexer_state current_state);
-bool			unmatched_parenthesis(void);
-bool			check_unmatched(t_lexer_state state, int open_paren_count);
+bool			unmatched_parenthesis(t_env *env);
+bool			check_unmatched(t_lexer_state state,
+					int open_paren_count, t_env *env);
 
-bool	quotes_paren_match(char *input)
+bool	quotes_paren_match(char *input, t_env *env)
 {
 	size_t			i;
 	t_lexer_state	state;
@@ -35,10 +36,10 @@ bool	quotes_paren_match(char *input)
 			else if (input[i] == ')')
 			{
 				if (open_paren_count == 0)
-					return (unmatched_parenthesis());
+					return (unmatched_parenthesis(env));
 				open_paren_count--;
 			}
 		}
 	}
-	return (check_unmatched(state, open_paren_count));
+	return (check_unmatched(state, open_paren_count, env));
 }

--- a/src/error_msg.c
+++ b/src/error_msg.c
@@ -15,25 +15,27 @@
 #include "libft.h"
 #include "minishell.h"
 
-bool	unmatched_parenthesis(void)
+bool	unmatched_parenthesis(t_env *env)
 {
 	ft_dprintf(STDERR_FILENO,
 		"syntax error with unmatched parenthesis\n");
+	env->exit_code = 2;
 	return (false);
 }
 
-static bool	unmatched_quotes(void)
+static bool	unmatched_quotes(t_env *env)
 {
 	ft_dprintf(STDERR_FILENO,
 		"syntax error with unmatched quotes\n");
+	env->exit_code = 2;
 	return (false);
 }
 
-bool	check_unmatched(t_lexer_state state, int open_paren_count)
+bool	check_unmatched(t_lexer_state state, int open_paren_count, t_env *env)
 {
 	if (state != TEXT)
-		return (unmatched_quotes());
+		return (unmatched_quotes(env));
 	if (open_paren_count != 0)
-		return (unmatched_parenthesis());
+		return (unmatched_parenthesis(env));
 	return (true);
 }

--- a/src/exec_pipe.c
+++ b/src/exec_pipe.c
@@ -17,7 +17,7 @@
 #include "minishell.h"
 #include "datastructures.h"
 
-void		exec_child(t_btree *node, int in_fd, int out_fd, t_gc *gc);
+void		exec_child(t_btree *node, int in_fd, int out_fd, t_env *env);
 t_darray	*flatten(t_btree *ast);
 
 static int	setup_fds(int *fds, bool is_last)
@@ -45,7 +45,7 @@ static void	fork_cleanup(int *fds, int *prev_fd)
 	*prev_fd = fds[0];
 }
 
-static pid_t	fork_cmd(t_btree *node, int *prev_fd, bool is_last, t_gc *gc)
+static pid_t	fork_cmd(t_btree *node, int *prev_fd, bool is_last, t_env *env)
 {
 	pid_t	pid;
 	int		fds[2];
@@ -66,7 +66,7 @@ static pid_t	fork_cmd(t_btree *node, int *prev_fd, bool is_last, t_gc *gc)
 	if (pid == 0 && fds[0] != STDIN_FILENO)
 		close(fds[0]);
 	if (pid == 0)
-		exec_child(node, *prev_fd, fds[1], gc);
+		exec_child(node, *prev_fd, fds[1], env);
 	fork_cleanup(fds, prev_fd);
 	return (pid);
 }
@@ -86,7 +86,7 @@ static int	wait_children(pid_t *pids, size_t len)
 	return (status >> 8);
 }
 
-int	exec_pipe(t_btree *ast)
+int	exec_pipe(t_btree *ast, t_env *env)
 {
 	t_darray	*nodes;
 	pid_t		*pids;
@@ -100,7 +100,7 @@ int	exec_pipe(t_btree *ast)
 	while (i < nodes->len)
 	{
 		pids[i] = fork_cmd(nodes->peek_i(nodes, i),
-				&prev_fd, i == nodes->len - 1, ast->gc);
+				&prev_fd, i == nodes->len - 1, env);
 		if (pids[i] == -1)
 			break ;
 		i++;

--- a/src/exec_pipe.c
+++ b/src/exec_pipe.c
@@ -20,13 +20,14 @@
 void		exec_child(t_btree *node, int in_fd, int out_fd, t_env *env);
 t_darray	*flatten(t_btree *ast);
 
-static int	setup_fds(int *fds, bool is_last)
+static int	setup_fds(int *fds, bool is_last, t_env *env)
 {
 	if (!is_last)
 	{
 		if (pipe(fds) == -1)
 		{
 			perror("pipe");
+			env->exit_code = 1;
 			return (-1);
 		}
 		return (0);
@@ -50,12 +51,13 @@ static pid_t	fork_cmd(t_btree *node, int *prev_fd, bool is_last, t_env *env)
 	pid_t	pid;
 	int		fds[2];
 
-	if (setup_fds(fds, is_last) == -1)
+	if (setup_fds(fds, is_last, env) == -1)
 		return (-1);
 	pid = fork();
 	if (pid == -1)
 	{
 		perror("fork");
+		env->exit_code = 1;
 		if (fds[1] != STDOUT_FILENO)
 		{
 			close(fds[0]);
@@ -71,7 +73,7 @@ static pid_t	fork_cmd(t_btree *node, int *prev_fd, bool is_last, t_env *env)
 	return (pid);
 }
 
-static int	wait_children(pid_t *pids, size_t len)
+static void	wait_children(pid_t *pids, size_t len, t_env *env)
 {
 	size_t	i;
 	int		status;
@@ -83,7 +85,7 @@ static int	wait_children(pid_t *pids, size_t len)
 			waitpid(pids[i], &status, 0);
 		i++;
 	}
-	return (status >> 8);
+	env->exit_code = status >> 8;
 }
 
 int	exec_pipe(t_btree *ast, t_env *env)
@@ -109,5 +111,6 @@ int	exec_pipe(t_btree *ast, t_env *env)
 		close(prev_fd);
 	if (i == 0)
 		return (1);
-	return (wait_children(pids, nodes->len));
+	wait_children(pids, nodes->len, env);
+	return (env->exit_code);
 }

--- a/src/exec_pipe_2.c
+++ b/src/exec_pipe_2.c
@@ -17,7 +17,7 @@
 #include "minishell.h"
 
 int		apply_redirs(t_cmd *cmd);
-int		exec_subshell(t_btree *ast, t_env *env);
+void	exec_subshell(t_btree *ast, t_env *env);
 
 static void	flatten_recur(t_btree *ast, t_darray *nodes)
 {
@@ -85,7 +85,7 @@ void	exec_child(t_btree *node, int in_fd, int out_fd, t_env *env)
 		env->gc->clean(env->gc);
 		exit(exit_code);
 	}
-	exit_code = exec_subshell(node, env);
+	exec_subshell(node, env);
 	env->gc->clean(env->gc);
-	exit(exit_code);
+	exit(0);
 }

--- a/src/exec_pipe_2.c
+++ b/src/exec_pipe_2.c
@@ -81,7 +81,8 @@ void	exec_child(t_btree *node, int in_fd, int out_fd, t_env *env)
 		cmd = token->cmd;
 		exit_code = apply_redirs(cmd, env);
 		if (exit_code == 0)
-			exit_code = gc_execvp(cmd->argv[0], cmd->argv, env->gc);
+			exit_code = gc_execvp(cmd->argv[0], cmd->argv,
+					(char **)env->envp->to_arr(env->envp), env->gc);
 		env->gc->clean(env->gc);
 		exit(exit_code);
 	}

--- a/src/exec_pipe_2.c
+++ b/src/exec_pipe_2.c
@@ -86,6 +86,7 @@ void	exec_child(t_btree *node, int in_fd, int out_fd, t_env *env)
 		exit(exit_code);
 	}
 	exec_subshell(node, env);
+	exit_code = env->exit_code;
 	env->gc->clean(env->gc);
-	exit(0);
+	exit(exit_code);
 }

--- a/src/exec_pipe_2.c
+++ b/src/exec_pipe_2.c
@@ -16,7 +16,7 @@
 #include "datastructures.h"
 #include "minishell.h"
 
-void	apply_redirs(t_cmd *cmd);
+int		apply_redirs(t_cmd *cmd);
 int		exec_subshell(t_btree *ast);
 int		gc_execvp(const char *cmd, char *const argv[], t_gc *gc);
 
@@ -80,8 +80,9 @@ void	exec_child(t_btree *node, int in_fd, int out_fd, t_gc *gc)
 	if (token->type == CMD)
 	{
 		cmd = token->cmd;
-		apply_redirs(cmd);
-		exit_code = gc_execvp(cmd->argv[0], cmd->argv, gc);
+		exit_code = apply_redirs(cmd);
+		if (exit_code == 0)
+			exit_code = gc_execvp(cmd->argv[0], cmd->argv, gc);
 		gc->clean(gc);
 		exit(exit_code);
 	}

--- a/src/exec_pipe_2.c
+++ b/src/exec_pipe_2.c
@@ -16,7 +16,7 @@
 #include "datastructures.h"
 #include "minishell.h"
 
-int		apply_redirs(t_cmd *cmd, t_env *env);
+bool	apply_redirs(t_cmd *cmd, t_env *env);
 void	exec_subshell(t_btree *ast, t_env *env);
 
 static void	flatten_recur(t_btree *ast, t_darray *nodes)

--- a/src/exec_pipe_2.c
+++ b/src/exec_pipe_2.c
@@ -79,10 +79,11 @@ void	exec_child(t_btree *node, int in_fd, int out_fd, t_env *env)
 	if (token->type == CMD)
 	{
 		cmd = token->cmd;
-		exit_code = apply_redirs(cmd, env);
-		if (exit_code == 0)
+		if (apply_redirs(cmd, env))
 			exit_code = gc_execvp(cmd->argv[0], cmd->argv,
 					(char **)env->envp->to_arr(env->envp), env->gc);
+		else
+			exit_code = env->exit_code;
 		env->gc->clean(env->gc);
 		exit(exit_code);
 	}

--- a/src/exec_pipe_2.c
+++ b/src/exec_pipe_2.c
@@ -16,7 +16,7 @@
 #include "datastructures.h"
 #include "minishell.h"
 
-int		apply_redirs(t_cmd *cmd);
+int		apply_redirs(t_cmd *cmd, t_env *env);
 void	exec_subshell(t_btree *ast, t_env *env);
 
 static void	flatten_recur(t_btree *ast, t_darray *nodes)
@@ -79,7 +79,7 @@ void	exec_child(t_btree *node, int in_fd, int out_fd, t_env *env)
 	if (token->type == CMD)
 	{
 		cmd = token->cmd;
-		exit_code = apply_redirs(cmd);
+		exit_code = apply_redirs(cmd, env);
 		if (exit_code == 0)
 			exit_code = gc_execvp(cmd->argv[0], cmd->argv, env->gc);
 		env->gc->clean(env->gc);

--- a/src/exec_pipe_2.c
+++ b/src/exec_pipe_2.c
@@ -17,7 +17,7 @@
 #include "minishell.h"
 
 int		apply_redirs(t_cmd *cmd);
-int		exec_subshell(t_btree *ast);
+int		exec_subshell(t_btree *ast, t_env *env);
 
 static void	flatten_recur(t_btree *ast, t_darray *nodes)
 {
@@ -68,24 +68,24 @@ static void	manage_dup(int in_fd, int out_fd, t_gc *gc)
 	}
 }
 
-void	exec_child(t_btree *node, int in_fd, int out_fd, t_gc *gc)
+void	exec_child(t_btree *node, int in_fd, int out_fd, t_env *env)
 {
 	t_token	*token;
 	t_cmd	*cmd;
 	int		exit_code;
 
-	manage_dup(in_fd, out_fd, gc);
+	manage_dup(in_fd, out_fd, env->gc);
 	token = node->value;
 	if (token->type == CMD)
 	{
 		cmd = token->cmd;
 		exit_code = apply_redirs(cmd);
 		if (exit_code == 0)
-			exit_code = gc_execvp(cmd->argv[0], cmd->argv, gc);
-		gc->clean(gc);
+			exit_code = gc_execvp(cmd->argv[0], cmd->argv, env->gc);
+		env->gc->clean(env->gc);
 		exit(exit_code);
 	}
-	exit_code = exec_subshell(node);
-	gc->clean(gc);
+	exit_code = exec_subshell(node, env);
+	env->gc->clean(env->gc);
 	exit(exit_code);
 }

--- a/src/exec_pipe_2.c
+++ b/src/exec_pipe_2.c
@@ -18,7 +18,6 @@
 
 int		apply_redirs(t_cmd *cmd);
 int		exec_subshell(t_btree *ast);
-int		gc_execvp(const char *cmd, char *const argv[], t_gc *gc);
 
 static void	flatten_recur(t_btree *ast, t_darray *nodes)
 {

--- a/src/executor.c
+++ b/src/executor.c
@@ -38,7 +38,8 @@ static void	exec_cmd(t_cmd *cmd, t_env *env)
 	{
 		exit_code = apply_redirs(cmd, env);
 		if (exit_code == 0)
-			exit_code = gc_execvp(cmd->argv[0], cmd->argv, env->gc);
+			exit_code = gc_execvp(cmd->argv[0], cmd->argv,
+				(char **)env->envp->to_arr(env->envp), env->gc);
 		env->gc->clean(env->gc);
 		exit(exit_code);
 	}

--- a/src/executor.c
+++ b/src/executor.c
@@ -18,7 +18,7 @@
 #include "minishell.h"
 
 int			exec_pipe(t_btree *ast, t_env *env);
-int			apply_redirs(t_cmd *cmd);
+int			apply_redirs(t_cmd *cmd, t_env *env);
 void		execute(t_btree *ast, t_env *env);
 
 static void	exec_cmd(t_cmd *cmd, t_env *env)
@@ -36,7 +36,7 @@ static void	exec_cmd(t_cmd *cmd, t_env *env)
 	}
 	if (pid == 0)
 	{
-		exit_code = apply_redirs(cmd);
+		exit_code = apply_redirs(cmd, env);
 		if (exit_code == 0)
 			exit_code = gc_execvp(cmd->argv[0], cmd->argv, env->gc);
 		env->gc->clean(env->gc);

--- a/src/executor.c
+++ b/src/executor.c
@@ -6,7 +6,7 @@
 /*   By: weizhang <weiqi.zhang_arthur@yahoo.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/03/27 15:34:51 by weizhang          #+#    #+#             */
-/*   Updated: 2026/03/27 16:15:27 by weizhang         ###   ########.fr       */
+/*   Updated: 2026/04/30 21:13:23 by weizhang         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,9 +19,9 @@
 
 int			exec_pipe(t_btree *ast, t_env *env);
 int			apply_redirs(t_cmd *cmd);
-int			execute(t_btree *ast, t_env *env);
+void		execute(t_btree *ast, t_env *env);
 
-static int	exec_cmd(t_cmd *cmd, t_env *env)
+static void	exec_cmd(t_cmd *cmd, t_env *env)
 {
 	pid_t	pid;
 	int		exit_code;
@@ -31,7 +31,7 @@ static int	exec_cmd(t_cmd *cmd, t_env *env)
 	if (pid == -1)
 	{
 		perror("fork");
-		return (1);
+		return ;
 	}
 	if (pid == 0)
 	{
@@ -42,62 +42,47 @@ static int	exec_cmd(t_cmd *cmd, t_env *env)
 		exit(exit_code);
 	}
 	waitpid(pid, &status, 0);
-	return (status >> 8);
 }
 
-int	exec_subshell(t_btree *ast, t_env *env)
+void	exec_subshell(t_btree *ast, t_env *env)
 {
 	pid_t	pid;
-	int		exit_code;
 	int		status;
 
 	pid = fork();
 	if (pid == -1)
 	{
 		perror("fork");
-		return (1);
+		return ;
 	}
 	if (pid == 0)
 	{
-		exit_code = execute(ast->left, env);
+		execute(ast->left, env);
 		ast->gc->clean(ast->gc);
-		exit(exit_code);
+		exit(0);
 	}
 	waitpid(pid, &status, 0);
-	return (status >> 8);
 }
 
-static int	exec_and(t_btree *ast, t_env *env)
-{
-	int	status;
-
-	status = execute(ast->left, env);
-	if (status == 0)
-		return (execute(ast->right, env));
-	return (status);
-}
-
-int	execute(t_btree *ast, t_env *env)
+void	execute(t_btree *ast, t_env *env)
 {
 	t_token	*current;
-	int		status;
 
 	current = ast->value;
 	if (current->type == CMD)
-		return (exec_cmd(current->cmd, env));
+		exec_cmd(current->cmd, env);
 	else if (current->type == AND)
-		return (exec_and(ast, env));
+	{
+		execute(ast->left, env);
+		execute(ast->right, env);
+	}
 	else if (current->type == OR)
 	{
-		status = execute(ast->left, env);
-		if (status != 0)
-			return (execute(ast->right, env));
-		return (status);
+		execute(ast->left, env);
+		execute(ast->right, env);
 	}
 	else if (current->type == PIPE)
-		return (exec_pipe(ast, env));
+		exec_pipe(ast, env);
 	else if (current->type == SUBSHELL)
-		return (exec_subshell(ast, env));
-	else
-		return (execute(ast->left, env));
+		exec_subshell(ast, env);
 }

--- a/src/executor.c
+++ b/src/executor.c
@@ -31,6 +31,7 @@ static void	exec_cmd(t_cmd *cmd, t_env *env)
 	if (pid == -1)
 	{
 		perror("fork");
+		env->exit_code = 1;
 		return ;
 	}
 	if (pid == 0)
@@ -42,6 +43,7 @@ static void	exec_cmd(t_cmd *cmd, t_env *env)
 		exit(exit_code);
 	}
 	waitpid(pid, &status, 0);
+	env->exit_code = status >> 8;
 }
 
 void	exec_subshell(t_btree *ast, t_env *env)
@@ -53,15 +55,18 @@ void	exec_subshell(t_btree *ast, t_env *env)
 	if (pid == -1)
 	{
 		perror("fork");
+		env->exit_code = 1;
 		return ;
 	}
 	if (pid == 0)
 	{
 		execute(ast->left, env);
+		status = env->exit_code;
 		ast->gc->clean(ast->gc);
-		exit(0);
+		exit(status);
 	}
 	waitpid(pid, &status, 0);
+	env->exit_code = status >> 8;
 }
 
 void	execute(t_btree *ast, t_env *env)
@@ -74,12 +79,14 @@ void	execute(t_btree *ast, t_env *env)
 	else if (current->type == AND)
 	{
 		execute(ast->left, env);
-		execute(ast->right, env);
+		if (env->exit_code == 0)
+			execute(ast->right, env);
 	}
 	else if (current->type == OR)
 	{
 		execute(ast->left, env);
-		execute(ast->right, env);
+		if (env->exit_code != 0)
+			execute(ast->right, env);
 	}
 	else if (current->type == PIPE)
 		exec_pipe(ast, env);

--- a/src/executor.c
+++ b/src/executor.c
@@ -21,10 +21,21 @@ int			exec_pipe(t_btree *ast, t_env *env);
 int			apply_redirs(t_cmd *cmd, t_env *env);
 void		execute(t_btree *ast, t_env *env);
 
+static void	exec_fork_child(t_cmd *cmd, t_env *env)
+{
+	int	status;
+
+	status = apply_redirs(cmd, env);
+	if (status == 0)
+		status = gc_execvp(cmd->argv[0], cmd->argv,
+				(char **)env->envp->to_arr(env->envp), env->gc);
+	env->gc->clean(env->gc);
+	exit(status);
+}
+
 static void	exec_cmd(t_cmd *cmd, t_env *env)
 {
 	pid_t	pid;
-	int		exit_code;
 	int		status;
 
 	pid = fork();
@@ -35,14 +46,7 @@ static void	exec_cmd(t_cmd *cmd, t_env *env)
 		return ;
 	}
 	if (pid == 0)
-	{
-		exit_code = apply_redirs(cmd, env);
-		if (exit_code == 0)
-			exit_code = gc_execvp(cmd->argv[0], cmd->argv,
-				(char **)env->envp->to_arr(env->envp), env->gc);
-		env->gc->clean(env->gc);
-		exit(exit_code);
-	}
+		exec_fork_child(cmd, env);
 	waitpid(pid, &status, 0);
 	env->exit_code = status >> 8;
 }

--- a/src/executor.c
+++ b/src/executor.c
@@ -17,7 +17,6 @@
 #include <sys/wait.h>
 #include "minishell.h"
 
-int			gc_execvp(const char *cmd, char *const argv[], t_gc *gc);
 int			exec_pipe(t_btree *ast);
 int			apply_redirs(t_cmd *cmd);
 int			execute(t_btree *ast);

--- a/src/executor.c
+++ b/src/executor.c
@@ -20,6 +20,23 @@
 int			exec_pipe(t_btree *ast, t_env *env);
 int			apply_redirs(t_cmd *cmd, t_env *env);
 void		execute(t_btree *ast, t_env *env);
+void		exec_builtins(char *cmd, char **options, t_env *env);
+bool		strs_eq(void *s1, void *s2);
+
+static void	exec_builtin_cmd(t_cmd *cmd, t_env *env)
+{
+	int	saved_stdin;
+	int	saved_stdout;
+
+	saved_stdin = dup(STDIN_FILENO);
+	saved_stdout = dup(STDOUT_FILENO);
+	if (apply_redirs(cmd, env) == 0)
+		exec_builtins(cmd->argv[0], cmd->argv, env);
+	dup2(saved_stdin, STDIN_FILENO);
+	dup2(saved_stdout, STDOUT_FILENO);
+	close(saved_stdin);
+	close(saved_stdout);
+}
 
 static void	exec_fork_child(t_cmd *cmd, t_env *env)
 {
@@ -38,6 +55,11 @@ static void	exec_cmd(t_cmd *cmd, t_env *env)
 	pid_t	pid;
 	int		status;
 
+	if (env->builtins->any(env->builtins, strs_eq, cmd->argv[0]))
+	{
+		exec_builtin_cmd(cmd, env);
+		return ;
+	}
 	pid = fork();
 	if (pid == -1)
 	{

--- a/src/executor.c
+++ b/src/executor.c
@@ -18,7 +18,7 @@
 #include "minishell.h"
 
 int			exec_pipe(t_btree *ast, t_env *env);
-int			apply_redirs(t_cmd *cmd, t_env *env);
+bool		apply_redirs(t_cmd *cmd, t_env *env);
 void		execute(t_btree *ast, t_env *env);
 void		exec_builtins(char *cmd, char **options, t_env *env);
 bool		strs_eq(void *s1, void *s2);

--- a/src/executor.c
+++ b/src/executor.c
@@ -17,11 +17,11 @@
 #include <sys/wait.h>
 #include "minishell.h"
 
-int			exec_pipe(t_btree *ast);
+int			exec_pipe(t_btree *ast, t_env *env);
 int			apply_redirs(t_cmd *cmd);
-int			execute(t_btree *ast);
+int			execute(t_btree *ast, t_env *env);
 
-static int	exec_cmd(t_cmd *cmd, t_gc *gc)
+static int	exec_cmd(t_cmd *cmd, t_env *env)
 {
 	pid_t	pid;
 	int		exit_code;
@@ -37,15 +37,15 @@ static int	exec_cmd(t_cmd *cmd, t_gc *gc)
 	{
 		exit_code = apply_redirs(cmd);
 		if (exit_code == 0)
-			exit_code = gc_execvp(cmd->argv[0], cmd->argv, gc);
-		gc->clean(gc);
+			exit_code = gc_execvp(cmd->argv[0], cmd->argv, env->gc);
+		env->gc->clean(env->gc);
 		exit(exit_code);
 	}
 	waitpid(pid, &status, 0);
 	return (status >> 8);
 }
 
-int	exec_subshell(t_btree *ast)
+int	exec_subshell(t_btree *ast, t_env *env)
 {
 	pid_t	pid;
 	int		exit_code;
@@ -59,7 +59,7 @@ int	exec_subshell(t_btree *ast)
 	}
 	if (pid == 0)
 	{
-		exit_code = execute(ast->left);
+		exit_code = execute(ast->left, env);
 		ast->gc->clean(ast->gc);
 		exit(exit_code);
 	}
@@ -67,37 +67,37 @@ int	exec_subshell(t_btree *ast)
 	return (status >> 8);
 }
 
-static int	exec_and(t_btree *ast)
+static int	exec_and(t_btree *ast, t_env *env)
 {
 	int	status;
 
-	status = execute(ast->left);
+	status = execute(ast->left, env);
 	if (status == 0)
-		return (execute(ast->right));
+		return (execute(ast->right, env));
 	return (status);
 }
 
-int	execute(t_btree *ast)
+int	execute(t_btree *ast, t_env *env)
 {
 	t_token	*current;
 	int		status;
 
 	current = ast->value;
 	if (current->type == CMD)
-		return (exec_cmd(current->cmd, ast->gc));
+		return (exec_cmd(current->cmd, env));
 	else if (current->type == AND)
-		return (exec_and(ast));
+		return (exec_and(ast, env));
 	else if (current->type == OR)
 	{
-		status = execute(ast->left);
+		status = execute(ast->left, env);
 		if (status != 0)
-			return (execute(ast->right));
+			return (execute(ast->right, env));
 		return (status);
 	}
 	else if (current->type == PIPE)
-		return (exec_pipe(ast));
+		return (exec_pipe(ast, env));
 	else if (current->type == SUBSHELL)
-		return (exec_subshell(ast));
+		return (exec_subshell(ast, env));
 	else
-		return (execute(ast->left));
+		return (execute(ast->left, env));
 }

--- a/src/executor.c
+++ b/src/executor.c
@@ -19,7 +19,7 @@
 
 int			gc_execvp(const char *cmd, char *const argv[], t_gc *gc);
 int			exec_pipe(t_btree *ast);
-void		apply_redirs(t_cmd *cmd);
+int			apply_redirs(t_cmd *cmd);
 int			execute(t_btree *ast);
 
 static int	exec_cmd(t_cmd *cmd, t_gc *gc)
@@ -36,8 +36,9 @@ static int	exec_cmd(t_cmd *cmd, t_gc *gc)
 	}
 	if (pid == 0)
 	{
-		apply_redirs(cmd);
-		exit_code = gc_execvp(cmd->argv[0], cmd->argv, gc);
+		exit_code = apply_redirs(cmd);
+		if (exit_code == 0)
+			exit_code = gc_execvp(cmd->argv[0], cmd->argv, gc);
 		gc->clean(gc);
 		exit(exit_code);
 	}

--- a/src/executor.c
+++ b/src/executor.c
@@ -10,6 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <unistd.h>
@@ -30,7 +31,7 @@ static void	exec_builtin_cmd(t_cmd *cmd, t_env *env)
 
 	saved_stdin = dup(STDIN_FILENO);
 	saved_stdout = dup(STDOUT_FILENO);
-	if (apply_redirs(cmd, env) == 0)
+	if (apply_redirs(cmd, env))
 		exec_builtins(cmd->argv[0], cmd->argv, env);
 	dup2(saved_stdin, STDIN_FILENO);
 	dup2(saved_stdout, STDOUT_FILENO);
@@ -42,10 +43,11 @@ static void	exec_fork_child(t_cmd *cmd, t_env *env)
 {
 	int	status;
 
-	status = apply_redirs(cmd, env);
-	if (status == 0)
+	if(apply_redirs(cmd, env))
 		status = gc_execvp(cmd->argv[0], cmd->argv,
 				(char **)env->envp->to_arr(env->envp), env->gc);
+	else
+		status = env->exit_code;
 	env->gc->clean(env->gc);
 	exit(status);
 }

--- a/src/lexer_postprocess.c
+++ b/src/lexer_postprocess.c
@@ -16,7 +16,7 @@
 #include "datastructures.h"
 #include "minishell.h"
 
-static t_token	*validate_redir(t_darray *ops, size_t i)
+static t_token	*validate_redir(t_darray *ops, size_t i, t_env *env)
 {
 	t_token	*next;
 
@@ -24,6 +24,7 @@ static t_token	*validate_redir(t_darray *ops, size_t i)
 	{
 		ft_dprintf(STDERR_FILENO,
 			"syntax error near unexpected token 'newline'\n");
+		env->exit_code = 2;
 		return (NULL);
 	}
 	next = ops->peek_i(ops, i + 1);
@@ -31,18 +32,19 @@ static t_token	*validate_redir(t_darray *ops, size_t i)
 	{
 		ft_dprintf(STDERR_FILENO,
 			"syntax error near unexpected token `%s'\n", next->value);
+		env->exit_code = 2;
 		return (NULL);
 	}
 	return (next);
 }
 
-static size_t	add_to_cmd(t_cmd *cmd, t_darray *ops, size_t i)
+static size_t	add_to_cmd(t_cmd *cmd, t_darray *ops, size_t i, t_env *env)
 {
 	t_token	*cur;
 	t_token	*next;
 
 	cur = ops->peek_i(ops, i);
-	next = validate_redir(ops, i);
+	next = validate_redir(ops, i, env);
 	if (!next)
 		return (0);
 	if (ft_strcmp(cur->value, ">") == 0)
@@ -57,7 +59,8 @@ static size_t	add_to_cmd(t_cmd *cmd, t_darray *ops, size_t i)
 	return (i + 2);
 }
 
-static size_t	collect_argv(t_darray *operands, size_t i, t_darray *cmds)
+static size_t	collect_argv(t_darray *operands, size_t i,
+		t_darray *cmds, t_env *env)
 {
 	t_darray	*argv;
 	t_token		*current;
@@ -72,7 +75,7 @@ static size_t	collect_argv(t_darray *operands, size_t i, t_darray *cmds)
 			argv->push(argv, current->value);
 		else if (current->type == REDIR)
 		{
-			i = add_to_cmd(cmd, operands, i);
+			i = add_to_cmd(cmd, operands, i, env);
 			if (i == 0)
 				return (0);
 		}
@@ -84,7 +87,7 @@ static size_t	collect_argv(t_darray *operands, size_t i, t_darray *cmds)
 	return (i);
 }
 
-t_darray	*postprocess(t_darray *operands)
+t_darray	*postprocess(t_darray *operands, t_env *env)
 {
 	t_darray	*cmds;
 	t_token		*current;
@@ -97,7 +100,7 @@ t_darray	*postprocess(t_darray *operands)
 		current = operands->peek_i(operands, i);
 		if (current->type & (OPERAND | REDIR))
 		{
-			i = collect_argv(operands, i, cmds);
+			i = collect_argv(operands, i, cmds, env);
 			if (i == 0)
 				return (NULL);
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -36,7 +36,7 @@ int	main(void)
 		ast = parse(input, env);
 		if (!ast)
 			continue ;
-		execute(ast);
+		execute(ast, env);
 	}
 	printf("exit\n");
 	rl_clear_history();

--- a/src/main.c
+++ b/src/main.c
@@ -23,15 +23,17 @@ int	main(void)
 	char		*input;
 	t_gc		*gc;
 	t_btree		*ast;
+	t_env		*env;
 
 	gc = init_gc();
+	env = init_env(gc);
 	while (true)
 	{
 		input = gc_readline("minishell> ", gc);
 		if (!input)
 			break ;
 		add_history(input);
-		ast = parse(input, gc);
+		ast = parse(input, env);
 		if (!ast)
 			continue ;
 		execute(ast);

--- a/src/parser.c
+++ b/src/parser.c
@@ -92,7 +92,7 @@ static t_btree	*parse_recur(t_darray *tokens, size_t *i, int min_bp)
 	return (node);
 }
 
-t_btree	*parse(char *input, t_gc *gc)
+t_btree	*parse(char *input, t_env *env)
 {
 	size_t		i;
 	t_darray	*tokens;
@@ -100,7 +100,7 @@ t_btree	*parse(char *input, t_gc *gc)
 
 	if (!quotes_paren_match(input))
 		return (NULL);
-	tokens = postprocess(tokenize(input, gc));
+	tokens = postprocess(tokenize(input, env->gc));
 	if (!tokens)
 		return (NULL);
 	i = 0;

--- a/src/parser.c
+++ b/src/parser.c
@@ -22,9 +22,11 @@ bool			quotes_paren_match(char *cmd, t_env *env);
 t_darray		*tokenize(char *cmd, t_gc *gc);
 t_darray		*postprocess(t_darray *operands);
 
-static t_btree	*parse_recur(t_darray *tokens, size_t *i, int min_bp);
+static t_btree	*parse_recur(t_darray *tokens,
+					size_t *i, int min_bp, t_env *env);
 
-static t_btree	*join_op(t_btree *left, t_darray *tokens, size_t *i)
+static t_btree	*join_op(t_btree *left, t_darray *tokens,
+		size_t *i, t_env *env)
 {
 	t_token	*op;
 	t_btree	*node;
@@ -35,17 +37,18 @@ static t_btree	*join_op(t_btree *left, t_darray *tokens, size_t *i)
 	{
 		ft_dprintf(STDERR_FILENO,
 			"syntax error near unexpected token `newline'\n");
+		env->exit_code = 2;
 		return (NULL);
 	}
 	node = init_btree(op, tokens->gc);
 	node->left = left;
-	node->right = parse_recur(tokens, i, op->bind_right);
+	node->right = parse_recur(tokens, i, op->bind_right, env);
 	if (!node->right)
 		return (NULL);
 	return (node);
 }
 
-static t_btree	*parse_atom(t_darray *tokens, size_t *i)
+static t_btree	*parse_atom(t_darray *tokens, size_t *i, t_env *env)
 {
 	t_token	*token;
 	t_btree	*node;
@@ -55,7 +58,7 @@ static t_btree	*parse_atom(t_darray *tokens, size_t *i)
 	{
 		node = init_btree(token, tokens->gc);
 		(*i)++;
-		node->left = parse_recur(tokens, i, 0);
+		node->left = parse_recur(tokens, i, 0, env);
 		if (!node->left)
 			return (NULL);
 		return (node);
@@ -64,19 +67,21 @@ static t_btree	*parse_atom(t_darray *tokens, size_t *i)
 	{
 		ft_dprintf(STDERR_FILENO,
 			"syntax error near unexpected token `%s'\n", token->value);
+		env->exit_code = 2;
 		return (NULL);
 	}
 	return (init_btree(token, tokens->gc));
 }
 
-static t_btree	*parse_recur(t_darray *tokens, size_t *i, int min_bp)
+static t_btree	*parse_recur(t_darray *tokens,
+		size_t *i, int min_bp, t_env *env)
 {
 	t_token	*token;
 	t_btree	*node;
 
 	if (*i >= tokens->len)
 		return (NULL);
-	node = parse_atom(tokens, i);
+	node = parse_atom(tokens, i, env);
 	if (!node)
 		return (NULL);
 	(*i)++;
@@ -85,7 +90,7 @@ static t_btree	*parse_recur(t_darray *tokens, size_t *i, int min_bp)
 		token = tokens->peek_i(tokens, *i);
 		if (token->type == CLOSE_PAREN || token->bind_left < min_bp)
 			break ;
-		node = join_op(node, tokens, i);
+		node = join_op(node, tokens, i, env);
 		if (!node)
 			return (NULL);
 	}
@@ -104,6 +109,6 @@ t_btree	*parse(char *input, t_env *env)
 	if (!tokens)
 		return (NULL);
 	i = 0;
-	ast = parse_recur(tokens, &i, 0);
+	ast = parse_recur(tokens, &i, 0, env);
 	return (ast);
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -18,7 +18,7 @@
 #include "libft.h"
 #include "minishell.h"
 
-bool			quotes_paren_match(char *cmd);
+bool			quotes_paren_match(char *cmd, t_env *env);
 t_darray		*tokenize(char *cmd, t_gc *gc);
 t_darray		*postprocess(t_darray *operands);
 
@@ -98,7 +98,7 @@ t_btree	*parse(char *input, t_env *env)
 	t_darray	*tokens;
 	t_btree		*ast;
 
-	if (!quotes_paren_match(input))
+	if (!quotes_paren_match(input, env))
 		return (NULL);
 	tokens = postprocess(tokenize(input, env->gc));
 	if (!tokens)

--- a/src/parser.c
+++ b/src/parser.c
@@ -20,7 +20,7 @@
 
 bool			quotes_paren_match(char *cmd, t_env *env);
 t_darray		*tokenize(char *cmd, t_gc *gc);
-t_darray		*postprocess(t_darray *operands);
+t_darray		*postprocess(t_darray *operands, t_env *env);
 
 static t_btree	*parse_recur(t_darray *tokens,
 					size_t *i, int min_bp, t_env *env);
@@ -105,7 +105,7 @@ t_btree	*parse(char *input, t_env *env)
 
 	if (!quotes_paren_match(input, env))
 		return (NULL);
-	tokens = postprocess(tokenize(input, env->gc));
+	tokens = postprocess(tokenize(input, env->gc), env);
 	if (!tokens)
 		return (NULL);
 	i = 0;

--- a/src/redir.c
+++ b/src/redir.c
@@ -18,7 +18,7 @@
 #include <unistd.h>
 #include "minishell.h"
 
-static bool	apply_from_file(t_redir *redir)
+static bool	apply_from_file(t_redir *redir, t_env *env)
 {
 	int		fd;
 	bool	flag;
@@ -28,18 +28,20 @@ static bool	apply_from_file(t_redir *redir)
 	if (fd == -1)
 	{
 		perror(redir->filename);
+		env->exit_code = 1;
 		return (false);
 	}
 	if (dup2(fd, STDIN_FILENO) == -1)
 	{
 		perror("dup2");
+		env->exit_code = 1;
 		flag = false;
 	}
 	close(fd);
 	return (flag);
 }
 
-static bool	apply_append_file(t_redir *redir)
+static bool	apply_append_file(t_redir *redir, t_env *env)
 {
 	int		fd;
 	bool	flag;
@@ -49,18 +51,20 @@ static bool	apply_append_file(t_redir *redir)
 	if (fd == -1)
 	{
 		perror(redir->filename);
+		env->exit_code = 1;
 		return (false);
 	}
 	if (dup2(fd, STDOUT_FILENO) == -1)
 	{
 		perror("dup2");
+		env->exit_code = 1;
 		flag = false;
 	}
 	close(fd);
 	return (flag);
 }
 
-static bool	apply_to_file(t_redir *redir)
+static bool	apply_to_file(t_redir *redir, t_env *env)
 {
 	int		fd;
 	bool	flag;
@@ -70,11 +74,13 @@ static bool	apply_to_file(t_redir *redir)
 	if (fd == -1)
 	{
 		perror(redir->filename);
+		env->exit_code = 1;
 		return (false);
 	}
 	if (dup2(fd, STDOUT_FILENO) == -1)
 	{
 		perror("dup2");
+		env->exit_code = 1;
 		flag = false;
 	}
 	close(fd);
@@ -87,18 +93,17 @@ bool	apply_redirs(t_cmd *cmd, t_env *env)
 	bool	flag;
 	size_t	i;
 
-	(void)env;
 	flag = true;
 	i = 0;
 	while (i < cmd->redirs->len)
 	{
 		redir = cmd->redirs->peek_i(cmd->redirs, i);
 		if (redir->redir_type == TO_FILE)
-			flag = apply_to_file(redir);
+			flag = apply_to_file(redir, env);
 		else if (redir->redir_type == APPEND_FILE)
-			flag = apply_append_file(redir);
+			flag = apply_append_file(redir, env);
 		else if (redir->redir_type == FROM_FILE)
-			flag = apply_from_file(redir);
+			flag = apply_from_file(redir, env);
 		if (!flag)
 			break ;
 		i++;

--- a/src/redir.c
+++ b/src/redir.c
@@ -20,7 +20,9 @@
 static int	apply_from_file(t_redir *redir)
 {
 	int	fd;
+	int	flag;
 
+	flag = 0;
 	fd = open(redir->filename, O_RDONLY);
 	if (fd == -1)
 	{
@@ -30,17 +32,18 @@ static int	apply_from_file(t_redir *redir)
 	if (dup2(fd, STDIN_FILENO) == -1)
 	{
 		perror("dup2");
-		close(fd);
-		return (1);
+		flag = 1;
 	}
 	close(fd);
-	return (0);
+	return (flag);
 }
 
 static int	apply_append_file(t_redir *redir)
 {
 	int	fd;
+	int	flag;
 
+	flag = 0;
 	fd = open(redir->filename, O_WRONLY | O_APPEND | O_CREAT, 0644);
 	if (fd == -1)
 	{
@@ -50,17 +53,18 @@ static int	apply_append_file(t_redir *redir)
 	if (dup2(fd, STDOUT_FILENO) == -1)
 	{
 		perror("dup2");
-		close(fd);
-		return (1);
+		flag = 1;
 	}
 	close(fd);
-	return (0);
+	return (flag);
 }
 
 static int	apply_to_file(t_redir *redir)
 {
 	int	fd;
+	int	flag;
 
+	flag = 0;
 	fd = open(redir->filename, O_WRONLY | O_TRUNC | O_CREAT, 0644);
 	if (fd == -1)
 	{
@@ -70,21 +74,20 @@ static int	apply_to_file(t_redir *redir)
 	if (dup2(fd, STDOUT_FILENO) == -1)
 	{
 		perror("dup2");
-		close(fd);
-		return (1);
+		flag = 1;
 	}
 	close(fd);
-	return (0);
+	return (flag);
 }
 
-int	apply_redirs(t_cmd *cmd)
+int	apply_redirs(t_cmd *cmd, t_env *env)
 {
 	t_redir	*redir;
-	int		flag;
 	size_t	i;
+	int		flag;
 
-	flag = 0;
 	i = 0;
+	flag = 0;
 	while (i < cmd->redirs->len)
 	{
 		redir = cmd->redirs->peek_i(cmd->redirs, i);
@@ -94,10 +97,11 @@ int	apply_redirs(t_cmd *cmd)
 			flag = apply_append_file(redir);
 		else if (redir->redir_type == FROM_FILE)
 			flag = apply_from_file(redir);
-		if (flag)
-			return (flag);
+		if (flag != 0)
+			break ;
 		i++;
 	}
+	env->exit_code = flag;
 	return (flag);
 }
 

--- a/src/redir.c
+++ b/src/redir.c
@@ -11,83 +11,85 @@
 /* ************************************************************************** */
 
 #include <fcntl.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
 #include "minishell.h"
 
-static int	apply_from_file(t_redir *redir)
+static bool	apply_from_file(t_redir *redir)
 {
-	int	fd;
-	int	flag;
+	int		fd;
+	bool	flag;
 
-	flag = 0;
+	flag = true;
 	fd = open(redir->filename, O_RDONLY);
 	if (fd == -1)
 	{
 		perror(redir->filename);
-		return (1);
+		return (false);
 	}
 	if (dup2(fd, STDIN_FILENO) == -1)
 	{
 		perror("dup2");
-		flag = 1;
+		flag = false;
 	}
 	close(fd);
 	return (flag);
 }
 
-static int	apply_append_file(t_redir *redir)
+static bool	apply_append_file(t_redir *redir)
 {
-	int	fd;
-	int	flag;
+	int		fd;
+	bool	flag;
 
-	flag = 0;
+	flag = true;
 	fd = open(redir->filename, O_WRONLY | O_APPEND | O_CREAT, 0644);
 	if (fd == -1)
 	{
 		perror(redir->filename);
-		return (1);
+		return (false);
 	}
 	if (dup2(fd, STDOUT_FILENO) == -1)
 	{
 		perror("dup2");
-		flag = 1;
+		flag = false;
 	}
 	close(fd);
 	return (flag);
 }
 
-static int	apply_to_file(t_redir *redir)
+static bool	apply_to_file(t_redir *redir)
 {
-	int	fd;
-	int	flag;
+	int		fd;
+	bool	flag;
 
-	flag = 0;
+	flag = true;
 	fd = open(redir->filename, O_WRONLY | O_TRUNC | O_CREAT, 0644);
 	if (fd == -1)
 	{
 		perror(redir->filename);
-		return (1);
+		return (false);
 	}
 	if (dup2(fd, STDOUT_FILENO) == -1)
 	{
 		perror("dup2");
-		flag = 1;
+		flag = false;
 	}
 	close(fd);
 	return (flag);
 }
 
-int	apply_redirs(t_cmd *cmd, t_env *env)
+bool	apply_redirs(t_cmd *cmd, t_env *env)
 {
 	t_redir	*redir;
+	bool	flag;
 	size_t	i;
-	int		flag;
 
+	(void)env;
+	flag = true;
 	i = 0;
-	flag = 0;
 	while (i < cmd->redirs->len)
 	{
 		redir = cmd->redirs->peek_i(cmd->redirs, i);
@@ -97,11 +99,10 @@ int	apply_redirs(t_cmd *cmd, t_env *env)
 			flag = apply_append_file(redir);
 		else if (redir->redir_type == FROM_FILE)
 			flag = apply_from_file(redir);
-		if (flag != 0)
+		if (!flag)
 			break ;
 		i++;
 	}
-	env->exit_code = flag;
 	return (flag);
 }
 

--- a/src/redir.c
+++ b/src/redir.c
@@ -11,12 +11,13 @@
 /* ************************************************************************** */
 
 #include <fcntl.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
 #include "minishell.h"
 
-static void	apply_from_file(t_redir *redir)
+static int	apply_from_file(t_redir *redir)
 {
 	int	fd;
 
@@ -24,19 +25,19 @@ static void	apply_from_file(t_redir *redir)
 	if (fd == -1)
 	{
 		perror(redir->filename);
-		redir->gc->clean(redir->gc);
-		exit(1);
+		return (1);
 	}
 	if (dup2(fd, STDIN_FILENO) == -1)
 	{
 		perror("dup2");
-		redir->gc->clean(redir->gc);
-		exit(1);
+		close(fd);
+		return (1);
 	}
 	close(fd);
+	return (0);
 }
 
-static void	apply_append_file(t_redir *redir)
+static int	apply_append_file(t_redir *redir)
 {
 	int	fd;
 
@@ -44,19 +45,19 @@ static void	apply_append_file(t_redir *redir)
 	if (fd == -1)
 	{
 		perror(redir->filename);
-		redir->gc->clean(redir->gc);
-		exit(1);
+		return (1);
 	}
 	if (dup2(fd, STDOUT_FILENO) == -1)
 	{
 		perror("dup2");
-		redir->gc->clean(redir->gc);
-		exit(1);
+		close(fd);
+		return (1);
 	}
 	close(fd);
+	return (0);
 }
 
-static void	apply_to_file(t_redir *redir)
+static int	apply_to_file(t_redir *redir)
 {
 	int	fd;
 
@@ -64,35 +65,40 @@ static void	apply_to_file(t_redir *redir)
 	if (fd == -1)
 	{
 		perror(redir->filename);
-		redir->gc->clean(redir->gc);
-		exit(1);
+		return (1);
 	}
 	if (dup2(fd, STDOUT_FILENO) == -1)
 	{
 		perror("dup2");
-		redir->gc->clean(redir->gc);
-		exit(1);
+		close(fd);
+		return (1);
 	}
 	close(fd);
+	return (0);
 }
 
-void	apply_redirs(t_cmd *cmd)
+int	apply_redirs(t_cmd *cmd)
 {
 	t_redir	*redir;
+	int		flag;
 	size_t	i;
 
+	flag = 0;
 	i = 0;
 	while (i < cmd->redirs->len)
 	{
 		redir = cmd->redirs->peek_i(cmd->redirs, i);
 		if (redir->redir_type == TO_FILE)
-			apply_to_file(redir);
+			flag = apply_to_file(redir);
 		else if (redir->redir_type == APPEND_FILE)
-			apply_append_file(redir);
+			flag = apply_append_file(redir);
 		else if (redir->redir_type == FROM_FILE)
-			apply_from_file(redir);
+			flag = apply_from_file(redir);
+		if (flag)
+			return (flag);
 		i++;
 	}
+	return (flag);
 }
 
 t_redir	*init_redir(t_redir_type redir_type, char *filename, t_gc *gc)

--- a/src/utils/gc_execvp.c
+++ b/src/utils/gc_execvp.c
@@ -18,44 +18,40 @@
 #include "gc_libft.h"
 #include "minishell.h"
 
-static char	**get_paths(t_gc *gc)
+static char	**get_paths(char **envp, t_gc *gc)
 {
 	size_t		i;
-	extern char	**environ;
 
 	i = 0;
-	while (environ[i])
+	while (envp[i])
 	{
-		if (ft_strncmp(environ[i], "PATH=", 5) == 0)
+		if (ft_strncmp(envp[i], "PATH=", 5) == 0)
 			break ;
 		i++;
 	}
-	if (!environ[i])
+	if (!envp[i])
 		return (NULL);
-	return (gc_split(environ[i] + 5, ':', gc));
+	return (gc_split(envp[i] + 5, ':', gc));
 }
 
-static int	exec_with_path(const char *cmd, char *const argv[])
+static int	exec_with_path(const char *cmd, char *const argv[], char **envp)
 {
-	extern char	**environ;
-
-	execve(cmd, argv, environ);
+	execve(cmd, argv, envp);
 	perror(cmd);
 	if (errno == EACCES)
 		return (126);
 	return (127);
 }
 
-int	gc_execvp(const char *cmd, char *const argv[], t_gc *gc)
+int	gc_execvp(const char *cmd, char *const argv[], char **envp, t_gc *gc)
 {
 	size_t		i;
 	char		*cmd_abs;
 	char		**paths;
-	extern char	**environ;
 
 	if (ft_strchr(cmd, '/'))
-		return (exec_with_path(cmd, argv));
-	paths = get_paths(gc);
+		return (exec_with_path(cmd, argv, envp));
+	paths = get_paths(envp, gc);
 	if (!paths)
 		return (127);
 	i = -1;
@@ -63,7 +59,7 @@ int	gc_execvp(const char *cmd, char *const argv[], t_gc *gc)
 	{
 		cmd_abs = gc_strjoin(gc_strjoin(paths[i], "/", gc), cmd, gc);
 		if (access(cmd_abs, X_OK) == 0)
-			execve(cmd_abs, argv, environ);
+			execve(cmd_abs, argv, envp);
 	}
 	ft_dprintf(STDERR_FILENO, "%s: command not found\n", cmd);
 	return (127);

--- a/src/utils/gc_execvp.c
+++ b/src/utils/gc_execvp.c
@@ -16,6 +16,7 @@
 #include <stddef.h>
 #include "libft.h"
 #include "gc_libft.h"
+#include "minishell.h"
 
 static char	**get_paths(t_gc *gc)
 {

--- a/src/utils/str_utils.c
+++ b/src/utils/str_utils.c
@@ -1,0 +1,24 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   str_utils.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: weizhang <weiqi.zhang_arthur@yahoo.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/05/01 23:55:28 by weizhang          #+#    #+#             */
+/*   Updated: 2026/05/01 23:56:37 by weizhang         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <stdbool.h>
+#include "libft.h"
+
+bool	strs_eq(void *s1, void *s2)
+{
+	return (ft_strcmp(s1, s2) == 0);
+}
+
+bool	startswith(void *s, void *ref)
+{
+	return (ft_strncmp(s, ref, ft_strlen(ref)) == 0);
+}

--- a/tests/test.norminette
+++ b/tests/test.norminette
@@ -20,10 +20,9 @@
 
 void		repr_token(void *ptr);
 void		repr_node(void *ptr);
-bool		quotes_paren_match(char *input);
-bool		is_valid_tree(t_btree *ast);
+bool		quotes_paren_match(char *input, t_env *env);
 t_darray	*tokenize(char *cmd, t_gc *gc);
-t_darray	*postprocess(t_darray *operands);
+t_darray	*postprocess(t_darray *operands, t_env *env);
 
 static void	test_t_token_case(t_gc *gc, char *s, char *expected_value,
 		t_token_type expected_type)
@@ -122,108 +121,108 @@ static void	test_parser_tokenize(t_gc *gc)
 	ft_printf("==========ALL TESTS PASSED==========\n\n");
 }
 
-static void	test_parser_is_valid_case(char *s, bool expected)
+static void	test_parser_is_valid_case(char *s, bool expected, t_env *env)
 {
 	ft_printf("Testing %s\n", s);
-	assert(quotes_paren_match(s) == expected);
+	assert(quotes_paren_match(s, env) == expected);
 }
 
-static void	test_parser_is_valid_cmd(void)
+static void	test_parser_is_valid_cmd(t_env *env)
 {
 	ft_printf("==========TEST_PARSER_IS_VALID_CMD==========\n");
 
 	// basic
-	test_parser_is_valid_case("", true);
-	test_parser_is_valid_case("echo hello", true);
+	test_parser_is_valid_case("", true, env);
+	test_parser_is_valid_case("echo hello", true, env);
 
 	// single quotes
-	test_parser_is_valid_case("'hello'", true);
-	test_parser_is_valid_case("''", true);
-	test_parser_is_valid_case("'", false);
-	test_parser_is_valid_case("'hello", false);
+	test_parser_is_valid_case("'hello'", true, env);
+	test_parser_is_valid_case("''", true, env);
+	test_parser_is_valid_case("'", false, env);
+	test_parser_is_valid_case("'hello", false, env);
 
 	// double quotes
-	test_parser_is_valid_case("\"hello\"", true);
-	test_parser_is_valid_case("\"\"", true);
-	test_parser_is_valid_case("\"", false);
-	test_parser_is_valid_case("\"hello", false);
+	test_parser_is_valid_case("\"hello\"", true, env);
+	test_parser_is_valid_case("\"\"", true, env);
+	test_parser_is_valid_case("\"", false, env);
+	test_parser_is_valid_case("\"hello", false, env);
 
 	// mixed quotes
-	test_parser_is_valid_case("\"'\"", true);
-	test_parser_is_valid_case("'\"'", true);
-	test_parser_is_valid_case("\"''\"", true);
-	test_parser_is_valid_case("'\"\"'", true);
-	test_parser_is_valid_case("\"'", false);
-	test_parser_is_valid_case("'\"", false);
-	test_parser_is_valid_case("\"'\"''", true);
-	test_parser_is_valid_case("'\"'\"'\"", true);
+	test_parser_is_valid_case("\"'\"", true, env);
+	test_parser_is_valid_case("'\"'", true, env);
+	test_parser_is_valid_case("\"''\"", true, env);
+	test_parser_is_valid_case("'\"\"'", true, env);
+	test_parser_is_valid_case("\"'", false, env);
+	test_parser_is_valid_case("'\"", false, env);
+	test_parser_is_valid_case("\"'\"''", true, env);
+	test_parser_is_valid_case("'\"'\"'\"", true, env);
 
 	// parentheses
-	test_parser_is_valid_case("()", true);
-	test_parser_is_valid_case("(())", true);
-	test_parser_is_valid_case("()()", true);
-	test_parser_is_valid_case("((()))", true);
-	test_parser_is_valid_case("(", false);
-	test_parser_is_valid_case(")", false);
-	test_parser_is_valid_case("((", false);
-	test_parser_is_valid_case("))", false);
-	test_parser_is_valid_case(")(", false);
-	test_parser_is_valid_case("(()", false);
-	test_parser_is_valid_case("())", false);
+	test_parser_is_valid_case("()", true, env);
+	test_parser_is_valid_case("(())", true, env);
+	test_parser_is_valid_case("()()", true, env);
+	test_parser_is_valid_case("((()))", true, env);
+	test_parser_is_valid_case("(", false, env);
+	test_parser_is_valid_case(")", false, env);
+	test_parser_is_valid_case("((", false, env);
+	test_parser_is_valid_case("))", false, env);
+	test_parser_is_valid_case(")(", false, env);
+	test_parser_is_valid_case("(()", false, env);
+	test_parser_is_valid_case("())", false, env);
 
 	// parentheses inside quotes (should be ignored)
-	test_parser_is_valid_case("'()'", true);
-	test_parser_is_valid_case("'('", true);
-	test_parser_is_valid_case("')'", true);
-	test_parser_is_valid_case("\"()\"", true);
-	test_parser_is_valid_case("\"(\"", true);
-	test_parser_is_valid_case("\")\"", true);
+	test_parser_is_valid_case("'()'", true, env);
+	test_parser_is_valid_case("'('", true, env);
+	test_parser_is_valid_case("')'", true, env);
+	test_parser_is_valid_case("\"()\"", true, env);
+	test_parser_is_valid_case("\"(\"", true, env);
+	test_parser_is_valid_case("\")\"", true, env);
 
 	// quotes inside parentheses
-	test_parser_is_valid_case("('hello')", true);
-	test_parser_is_valid_case("(\"hello\")", true);
+	test_parser_is_valid_case("('hello')", true, env);
+	test_parser_is_valid_case("(\"hello\")", true, env);
 
 	// combined edge cases
-	test_parser_is_valid_case("''()()", true);
-	test_parser_is_valid_case("(\")\"", false);
-	test_parser_is_valid_case("(')'", false);
-	test_parser_is_valid_case("\"(\")", false);
-	test_parser_is_valid_case("'(')", false);
+	test_parser_is_valid_case("''()()", true, env);
+	test_parser_is_valid_case("(\")\"", false, env);
+	test_parser_is_valid_case("(')'", false, env);
+	test_parser_is_valid_case("\"(\")", false, env);
+	test_parser_is_valid_case("'(')", false, env);
 
 	// realistic commands
-	test_parser_is_valid_case("(echo hello && echo world)", true);
-	test_parser_is_valid_case("(echo hello && (echo world))", true);
-	test_parser_is_valid_case("echo 'unclosed", false);
-	test_parser_is_valid_case("echo \"unclosed", false);
+	test_parser_is_valid_case("(echo hello && echo world)", true, env);
+	test_parser_is_valid_case("(echo hello && (echo world))", true, env);
+	test_parser_is_valid_case("echo 'unclosed", false, env);
+	test_parser_is_valid_case("echo \"unclosed", false, env);
 
 	ft_printf("==========ALL TESTS PASSED==========\n\n");
 }
 
-static void	postprocess_helper(char *cmd, t_gc *gc)
+static void	postprocess_helper(char *cmd, t_env *env)
 {
 	t_darray	*cmds;
 
 	ft_printf("Testing %s\n", cmd);
-	cmds = postprocess(tokenize(cmd, gc));
+	cmds = postprocess(tokenize(cmd, env->gc), env);
 	cmds->repr(cmds, repr_token);
 	return ;
 }
 
-static void	test_parser_postprocess(t_gc *gc)
+static void	test_parser_postprocess(t_env *env)
 {
 	ft_printf("==========TEST_PARSER_POSTPROCESS==========\n");
 
-	postprocess_helper( "ls -la | grep hello > test.txt", gc);
+	postprocess_helper("ls -la | grep hello > test.txt", env);
 
 	ft_printf("==========ALL TESTS PASSED==========\n\n");
 }
 
-static void	test_parser_parse_case(t_gc *gc, char *s, bool expected)
+static void	test_parser_parse_case(t_env *env, char *s, bool expected)
 {
 	t_btree		*ast;
 
 	ft_printf("Testing %s\n", s);
-	ast = parse(s, gc);
+	ast = parse(s, env);
 	if (expected)
 	{
 		assert(ast != NULL);
@@ -234,205 +233,214 @@ static void	test_parser_parse_case(t_gc *gc, char *s, bool expected)
 	ft_printf("\n");
 }
 
-static void	test_parser_parse(t_gc *gc)
+static void	test_parser_parse(t_env *env)
 {
 	ft_printf("==========TEST_PARSER_PARSE==========\n");
 
-	test_parser_parse_case(gc, "ls -l", true);
-	test_parser_parse_case(gc, "ls -l && grep something", true);
-	test_parser_parse_case(gc, "expr1 && expr2 || expr3 | expr4", true);
-	test_parser_parse_case(gc, "a | b && c || d", true);
-	test_parser_parse_case(gc, "a | b | c && d | e || f && g", true);
+	test_parser_parse_case(env, "ls -l", true);
+	test_parser_parse_case(env, "ls -l && grep something", true);
+	test_parser_parse_case(env, "expr1 && expr2 || expr3 | expr4", true);
+	test_parser_parse_case(env, "a | b && c || d", true);
+	test_parser_parse_case(env, "a | b | c && d | e || f && g", true);
 
 	// Invalid trees
-	test_parser_parse_case(gc, "ls |", false);
-	test_parser_parse_case(gc, "|| | && echo hello", false);
+	test_parser_parse_case(env, "ls |", false);
+	test_parser_parse_case(env, "|| | && echo hello", false);
 
 	// operator at the beginning
-	test_parser_parse_case(gc, "&& ls", false);
-	test_parser_parse_case(gc, "| ls", false);
-	test_parser_parse_case(gc, "|| ls", false);
+	test_parser_parse_case(env, "&& ls", false);
+	test_parser_parse_case(env, "| ls", false);
+	test_parser_parse_case(env, "|| ls", false);
 
 	// operator at the end
-	test_parser_parse_case(gc, "ls &&", false);
-	test_parser_parse_case(gc, "ls ||", false);
+	test_parser_parse_case(env, "ls &&", false);
+	test_parser_parse_case(env, "ls ||", false);
 
 	// consecutive operators
-	test_parser_parse_case(gc, "ls && || echo hi", false);
-	test_parser_parse_case(gc, "ls | | echo hi", false);
-	test_parser_parse_case(gc, "ls || && echo hi", false);
+	test_parser_parse_case(env, "ls && || echo hi", false);
+	test_parser_parse_case(env, "ls | | echo hi", false);
+	test_parser_parse_case(env, "ls || && echo hi", false);
 
 	// only operators
-	test_parser_parse_case(gc, "|", false);
-	test_parser_parse_case(gc, "&&", false);
-	test_parser_parse_case(gc, "||", false);
+	test_parser_parse_case(env, "|", false);
+	test_parser_parse_case(env, "&&", false);
+	test_parser_parse_case(env, "||", false);
 
 	// parentheses - valid
-	test_parser_parse_case(gc, "(a)", true);
-	test_parser_parse_case(gc, "(a && b)", true);
-	test_parser_parse_case(gc, "(a) && b", true);
-	test_parser_parse_case(gc, "a && (b)", true);
-	test_parser_parse_case(gc, "(a) && (b)", true);
-	test_parser_parse_case(gc, "a || (b && c)", true);
-	test_parser_parse_case(gc, "(a | b) && c", true);
-	test_parser_parse_case(gc, "(a && (b || c))", true);
-	test_parser_parse_case(gc, "((a || b) && (c || d))", true);
-	test_parser_parse_case(gc, "a && (b | c) || d", true);
-	test_parser_parse_case(gc, "(ls -l | grep foo) && echo yes || echo no", true);
+	test_parser_parse_case(env, "(a)", true);
+	test_parser_parse_case(env, "(a && b)", true);
+	test_parser_parse_case(env, "(a) && b", true);
+	test_parser_parse_case(env, "a && (b)", true);
+	test_parser_parse_case(env, "(a) && (b)", true);
+	test_parser_parse_case(env, "a || (b && c)", true);
+	test_parser_parse_case(env, "(a | b) && c", true);
+	test_parser_parse_case(env, "(a && (b || c))", true);
+	test_parser_parse_case(env, "((a || b) && (c || d))", true);
+	test_parser_parse_case(env, "a && (b | c) || d", true);
+	test_parser_parse_case(env,
+		"(ls -l | grep foo) && echo yes || echo no", true);
 
 	// parentheses - invalid
 
 	// empty subshell
-	test_parser_parse_case(gc, "()", false);
+	test_parser_parse_case(env, "()", false);
 
 	// subshell with only an operator inside
-	test_parser_parse_case(gc, "(|)", false);
-	test_parser_parse_case(gc, "(&&)", false);
+	test_parser_parse_case(env, "(|)", false);
+	test_parser_parse_case(env, "(&&)", false);
 
 	// operator before subshell (no left operand)
-	test_parser_parse_case(gc, "&& (a)", false);
-	test_parser_parse_case(gc, "| (a)", false);
-	test_parser_parse_case(gc, "|| (a)", false);
+	test_parser_parse_case(env, "&& (a)", false);
+	test_parser_parse_case(env, "| (a)", false);
+	test_parser_parse_case(env, "|| (a)", false);
 
 	// operator after subshell with nothing following
-	test_parser_parse_case(gc, "(a) &&", false);
-	test_parser_parse_case(gc, "(a) |", false);
-	test_parser_parse_case(gc, "(a) ||", false);
+	test_parser_parse_case(env, "(a) &&", false);
+	test_parser_parse_case(env, "(a) |", false);
+	test_parser_parse_case(env, "(a) ||", false);
 
 	// consecutive operators inside subshell
-	test_parser_parse_case(gc, "(a && || b)", false);
-	test_parser_parse_case(gc, "(a | | b)", false);
+	test_parser_parse_case(env, "(a && || b)", false);
+	test_parser_parse_case(env, "(a | | b)", false);
 
 	// operator at start inside subshell
-	test_parser_parse_case(gc, "(| a)", false);
-	test_parser_parse_case(gc, "(&& a)", false);
+	test_parser_parse_case(env, "(| a)", false);
+	test_parser_parse_case(env, "(&& a)", false);
 
 	// operator at end inside subshell
-	test_parser_parse_case(gc, "(a |)", false);
-	test_parser_parse_case(gc, "(a &&)", false);
+	test_parser_parse_case(env, "(a |)", false);
+	test_parser_parse_case(env, "(a &&)", false);
 
 	// nested empty subshell
-	test_parser_parse_case(gc, "(())", false);
+	test_parser_parse_case(env, "(())", false);
 
-	// subshell with command on right side (invalid: subshell cannot have right child)
-	test_parser_parse_case(gc, "(a) b", false);
+	// subshell with command on right side
+	test_parser_parse_case(env, "(a) b", false);
 
 	ft_printf("==========ALL TESTS PASSED==========\n\n");
 }
 
 
-static void	test_exec_case(t_gc *gc, char *cmd)
+static void	test_exec_case(t_env *env, char *cmd)
 {
 	t_btree		*ast;
 
 	ft_printf("Testing exec: %s\n", cmd);
-	ast = parse(cmd, gc);
-	execute(ast);
+	ast = parse(cmd, env);
+	execute(ast, env);
 	ft_printf("\n");
 }
 
-static void	test_exec(t_gc *gc)
+static void	test_exec(t_env *env)
 {
 	ft_printf("==========TEST_EXEC==========\n");
 
 	// test single cmd
-	test_exec_case(gc, "echo hello");
-	test_exec_case(gc, "echo hello world");
-	test_exec_case(gc, "echo -n hello");
-	test_exec_case(gc, "ls -l");
-	test_exec_case(gc, "/bin/echo bonjour");
+	test_exec_case(env, "echo hello");
+	test_exec_case(env, "echo hello world");
+	test_exec_case(env, "echo -n hello");
+	test_exec_case(env, "ls -l");
+	test_exec_case(env, "/bin/echo bonjour");
 
 
 	// test &&
-	test_exec_case(gc, "ls -l && echo success");
+	test_exec_case(env, "ls -l && echo success");
 
 	// test ||
-	test_exec_case(gc, "ls -l || echo wrong");
-	test_exec_case(gc, "invalid || echo wrong");
+	test_exec_case(env, "ls -l || echo wrong");
+	test_exec_case(env, "invalid || echo wrong");
 
 	// test |
-	test_exec_case(gc, "echo hello | cat -e | cat -e");
+	test_exec_case(env, "echo hello | cat -e | cat -e");
 
 	// test && || | combined (no parentheses)
-	test_exec_case(gc, "echo hello | cat -e && echo done");
-	test_exec_case(gc, "ls nonexistent && echo yes || echo no");
-	test_exec_case(gc, "echo start && echo hello | cat -e");
-	test_exec_case(gc,
+	test_exec_case(env, "echo hello | cat -e && echo done");
+	test_exec_case(env, "ls nonexistent && echo yes || echo no");
+	test_exec_case(env, "echo start && echo hello | cat -e");
+	test_exec_case(env,
 		"ls nonexistent || echo b && echo c | cat -e");
 
 	// test subshell
-	test_exec_case(gc, "(echo hello)");
-	test_exec_case(gc, "(echo hello && echo world)");
-	test_exec_case(gc, "(echo hello || echo world)");
-	test_exec_case(gc, "(echo hello | cat -e)");
+	test_exec_case(env, "(echo hello)");
+	test_exec_case(env, "(echo hello && echo world)");
+	test_exec_case(env, "(echo hello || echo world)");
+	test_exec_case(env, "(echo hello | cat -e)");
 
 	// subshell with && / ||
-	test_exec_case(gc, "(echo hello) && echo after");
-	test_exec_case(gc, "(ls nonexistent) || echo fallback");
-	test_exec_case(gc, "(ls nonexistent) && echo no || echo yes");
+	test_exec_case(env, "(echo hello) && echo after");
+	test_exec_case(env, "(ls nonexistent) || echo fallback");
+	test_exec_case(env, "(ls nonexistent) && echo no || echo yes");
 
 	// subshell with pipe
-	test_exec_case(gc, "(echo hello) | cat -e");
-	test_exec_case(gc, "echo start | (cat -e)");
+	test_exec_case(env, "(echo hello) | cat -e");
+	test_exec_case(env, "echo start | (cat -e)");
 
 	// nested subshell
-	test_exec_case(gc, "((echo nested))");
-	test_exec_case(gc, "(echo a && (echo b || echo c))");
-	test_exec_case(gc, "((echo a | cat -e) && echo b)");
+	test_exec_case(env, "((echo nested))");
+	test_exec_case(env, "(echo a && (echo b || echo c))");
+	test_exec_case(env, "((echo a | cat -e) && echo b)");
 
 	// subshell combined with operators outside
-	test_exec_case(gc,
+	test_exec_case(env,
 		"(echo a && echo b) || (echo c && echo d)");
-	test_exec_case(gc,
+	test_exec_case(env,
 		"(ls nonexistent || echo recover) && echo done");
-	test_exec_case(gc,
+	test_exec_case(env,
 		"(echo hello | cat -e) && (echo world | cat -e)");
 
 	ft_printf("==========ALL TESTS PASSED==========\n\n");
 }
 
 t_darray	*flatten(t_btree *ast);
-static void	test_flatten_case(char *cmd, t_gc *gc)
+static void	test_flatten_case(char *cmd, t_env *env)
 {
 	t_btree		*ast;
 	t_darray	*flattened;
 
 	ft_printf("Testing %s\n", cmd);
-	ast = parse(cmd, gc);
+	ast = parse(cmd, env);
 	flattened = flatten(ast);
 	flattened->repr(flattened, repr_node);
 	ft_printf("\n");
 }
 
-static void	test_flatten(t_gc *gc)
+static void	test_flatten(t_env *env)
 {
 	ft_printf("==========TEST_FLATTEN==========\n\n");
 
-	test_flatten_case("ls -l | cat -e", gc);
-	test_flatten_case("a | b | c | d", gc);
-	test_flatten_case("a|b|c", gc);
+	test_flatten_case("ls -l | cat -e", env);
+	test_flatten_case("a | b | c | d", env);
+	test_flatten_case("a|b|c", env);
 
 	ft_printf("==========ALL TESTS PASSED==========\n\n");
 }
-static void	test_error_handling_case(char *cmd, int expected_exit_code, t_gc *gc)
+
+static void	test_error_handling_case(char *cmd, int expected_exit_code,
+		t_env *env)
 {
+	t_btree	*ast;
+
 	ft_printf("%s\n", cmd);
-	assert(execute(parse(cmd, gc)) == expected_exit_code);
+	ast = parse(cmd, env);
+	assert(ast != NULL);
+	execute(ast, env);
+	assert(env->exit_code == expected_exit_code);
 	ft_printf("\n");
 }
 
-static void	test_error_handling(t_gc *gc)
+static void	test_error_handling(t_env *env)
 {
 	ft_printf("==========TEST_ERROR_HANDLING==========\n\n");
 
-	test_error_handling_case("echo hello > no_permisson.tmp", 1, gc);
-	test_error_handling_case("echo hello >> no_permisson.tmp", 1, gc);
-	test_error_handling_case("echo hello >> no_permisson.tmp | echo hello", 0, gc);
-	test_error_handling_case("< no_permisson.tmp cat", 1, gc);
-	test_error_handling_case("./no_exist_file", 127, gc);
-	test_error_handling_case("/no_exist_file", 127, gc);
-	test_error_handling_case("no_exist_cmd", 127, gc);
-	test_error_handling_case("./no_permisson.tmp", 126, gc);
+	test_error_handling_case("echo hello > no_permisson.tmp", 1, env);
+	test_error_handling_case("echo hello >> no_permisson.tmp", 1, env);
+	test_error_handling_case(
+		"echo hello >> no_permisson.tmp | echo hello", 0, env);
+	test_error_handling_case("< no_permisson.tmp cat", 1, env);
+	test_error_handling_case("./no_exist_file", 127, env);
+	test_error_handling_case("/no_exist_file", 127, env);
+	test_error_handling_case("no_exist_cmd", 127, env);
+	test_error_handling_case("./no_permisson.tmp", 126, env);
 
 	ft_printf("==========ALL TESTS PASSED==========\n\n");
 }
@@ -440,15 +448,17 @@ static void	test_error_handling(t_gc *gc)
 int main(void)
 {
 	t_gc	*gc;
+	t_env	*env;
 
 	gc = init_gc();
+	env = init_env(gc);
 	test_t_token(gc);
-	test_parser_is_valid_cmd();
+	test_parser_is_valid_cmd(env);
 	test_parser_tokenize(gc);
-	test_parser_postprocess(gc);
-	test_parser_parse(gc);
-	test_flatten(gc);
-	test_exec(gc);
-	test_error_handling(gc);
+	test_parser_postprocess(env);
+	test_parser_parse(env);
+	test_flatten(env);
+	test_exec(env);
+	test_error_handling(env);
 	gc->clean(gc);
 }


### PR DESCRIPTION
# Add pwd builtin with t_env infrastructure

## Overview

This PR adds a `pwd` builtin command and introduces the `t_env` struct to thread environment state (exit codes, builtins list, environment variables) through the entire shell pipeline, replacing scattered `exit()` calls and global `environ` references.

## Key changes

- **darray extensions**: Added `any()`, `find()`, and `init_from_arr()` to the dynamic array data structure, enabling predicate-based search and array initialization from raw pointer arrays.

- **String utilities**: Added `strs_eq()` and `startswith()` helpers for comparing void pointers as strings, used by the builtin dispatch logic.

- **Redir error handling**: Redirections now return error codes instead of calling `exit()` directly, allowing the caller to decide how to handle failures. This is necessary for builtins that run in the parent process.

- **`t_env` struct**: A new struct holding `exit_code`, `builtins` (list of builtin names), `envp` (environment variables as a darray), and `gc` (garbage collector). Threaded through the entire parse and execute chains, replacing the previous pattern of passing `t_gc *gc` separately and using the return value of `execute()` for exit codes. Exit code will be updated internally inside function instead of being returned and captured by functions.

- **`gc_execvp` envp parameter**: `gc_execvp` now accepts an explicit `char **envp` parameter instead of reading the global `environ`, preparing for future environment variable manipulation.

- **pwd builtin**: Runs in the parent process (no fork) with stdin/stdout save-restore for redirections. Builtin dispatch checks the command against a registered list before deciding whether to fork.

## Design decisions

- Builtins run in the parent process to allow them to modify shell state (exit code, future: environment variables, current directory). The executor saves/restores file descriptors around builtin execution to support redirections without forking.

- The `t_env` struct centralizes shell state that was previously scattered (return values, global environ, gc pointer), making it straightforward to add more builtins and shell variables later.
