### PR TITLE
Expander/question mark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ SRC = ./src/checker.c \
 	  ./src/exec_pipe.c \
 	  ./src/exec_pipe_2.c \
 	  ./src/executor.c \
+	  ./src/expander.c \
 	  ./src/lexer.c \
 	  ./src/lexer_postprocess.c \
 	  ./src/main.c \

--- a/include/datastructures.h
+++ b/include/datastructures.h
@@ -36,6 +36,7 @@ struct s_darray
 	void	(*push)(t_darray *self, void *item);
 	void	*(*pop_i)(t_darray *self, size_t i);
 	void	*(*pop)(t_darray *self);
+	void	(*set)(t_darray *self, size_t i, void *item);
 	bool	(*any)(t_darray * self, bool (*f)(void *, void *), void *target);
 	void	*(*find)(t_darray *s, bool (*f)(void *e1, void *e2), void *e2);
 	size_t	(*find_i)(t_darray *s, bool (*f)(void *e1, void *e2), void *e2);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -40,10 +40,10 @@ t_redir		*init_redir(t_redir_type type, char *filename, t_gc *gc);
 typedef struct s_cmd	t_cmd;
 struct s_cmd
 {
-	char		**argv;
+	t_darray	*argv;
 	t_darray	*redirs;
 	t_gc		*gc;
-	void		(*set_argv)(t_cmd *self, char **argv);
+	void		(*set_argv)(t_cmd *self, t_darray *argv);
 	void		(*push_redir)(t_cmd *self, t_redir *redir);
 };
 t_cmd		*init_cmd(t_gc *gc);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,9 +3,11 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: anying <anying@student.42.fr>              +#+  +:+       +#+        */
+/*   By: weizhang <weiqi.zhang_arthur@yahoo.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2026/03/14 21:07:26 by weizhang          #+#    #+#             */ /*   Updated: 2026/03/29 00:00:55 by weizhang         ###   ########.fr       */ /*                                                                            */
+/*   Created: 2026/05/11 00:19:44 by weizhang          #+#    #+#             */
+/*   Updated: 2026/05/11 00:19:46 by weizhang         ###   ########.fr       */
+/*                                                                            */
 /* ************************************************************************** */
 
 #ifndef MINISHELL_H
@@ -29,12 +31,14 @@ typedef enum e_redir_type
 	FROM_FILE,
 }	t_redir_type;
 
-typedef struct s_redir
+typedef struct s_redir	t_redir;
+struct s_redir
 {
 	t_redir_type	redir_type;
 	char			*filename;
 	t_gc			*gc;
-}	t_redir;
+	void			(*set_filename)(t_redir *self, char *filename);
+};
 t_redir		*init_redir(t_redir_type type, char *filename, t_gc *gc);
 
 typedef struct s_cmd	t_cmd;

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -96,6 +96,7 @@ int			gc_execvp(const char *cmd, char *const argv[],
 char		*gc_readline(const char *prompt, t_gc *gc);
 char		*gc_getcwd(t_gc *gc);
 t_btree		*parse(char *input, t_env *env);
+void		expand_cmd(t_cmd *cmd, t_env *env);
 void		execute(t_btree *ast, t_env *env);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -22,6 +22,7 @@ typedef enum e_dfa_state
 	TEXT,
 	SINGLE,
 	DOUBLE,
+	DOLLAR,
 }	t_dfa_state;
 
 typedef enum e_redir_type

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -90,6 +90,7 @@ int			gc_execvp(const char *cmd, char *const argv[],
 char		*gc_readline(const char *prompt, t_gc *gc);
 char		*gc_getcwd(t_gc *gc);
 t_btree		*parse(char *input, t_env *env);
+void		expand_ast(t_btree *ast, t_env *env);
 void		execute(t_btree *ast, t_env *env);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -96,7 +96,6 @@ int			gc_execvp(const char *cmd, char *const argv[],
 char		*gc_readline(const char *prompt, t_gc *gc);
 char		*gc_getcwd(t_gc *gc);
 t_btree		*parse(char *input, t_env *env);
-void		expand_ast(t_btree *ast, t_env *env);
 void		execute(t_btree *ast, t_env *env);
 
 #endif

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -23,6 +23,7 @@ typedef enum e_dfa_state
 	SINGLE,
 	DOUBLE,
 	DOLLAR,
+	ALPHA,
 }	t_dfa_state;
 
 typedef enum e_redir_type

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -17,12 +17,12 @@
 # include "gc_libft.h"
 # include "datastructures.h"
 
-typedef enum e_lexer_state
+typedef enum e_dfa_state
 {
 	TEXT,
 	SINGLE,
 	DOUBLE,
-}	t_lexer_state;
+}	t_dfa_state;
 
 typedef enum e_redir_type
 {

--- a/lib/datastructures/darray_basic.c
+++ b/lib/datastructures/darray_basic.c
@@ -21,6 +21,7 @@ void	insert(t_darray *self, size_t i, void *item);
 void	push(t_darray *self, void *item);
 void	*pop_i(t_darray *self, size_t i);
 void	*pop(t_darray *self);
+void	set(t_darray *self, size_t i, void *item);
 bool	any(t_darray *s, bool (*f)(void *elem, void *target), void *target);
 void	*find(t_darray *s, bool (*f)(void *e1, void *e2), void *e2);
 size_t	find_i(t_darray *s, bool (*f)(void *e1, void *e2), void *e2);
@@ -79,6 +80,7 @@ t_darray	*init_darray(t_gc *gc)
 	darray->push = push;
 	darray->pop_i = pop_i;
 	darray->pop = pop;
+	darray->set = set;
 	darray->any = any;
 	darray->find = find;
 	darray->find_i = find_i;

--- a/lib/datastructures/darray_io_2.c
+++ b/lib/datastructures/darray_io_2.c
@@ -10,6 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <unistd.h>
 #include "datastructures.h"
 
 void	*peek_i(t_darray *self, size_t i)
@@ -30,4 +31,15 @@ void	*peek(t_darray *self)
 		return (NULL);
 	}
 	return (peek_i(self, self->len - 1));
+}
+
+void	set(t_darray *self, size_t i, void *item)
+{
+	if (i + 1 > self->len)
+	{
+		ft_dprintf(STDERR_FILENO,
+				"IndexError: darray len %d while set at %d\n", self->len, i);
+		return ;
+	}
+	self->arr[i] = item;
 }

--- a/src/checker.c
+++ b/src/checker.c
@@ -12,16 +12,16 @@
 
 #include "minishell.h"
 
-t_lexer_state	update_state(char c, t_lexer_state current_state);
-bool			unmatched_parenthesis(t_env *env);
-bool			check_unmatched(t_lexer_state state,
-					int open_paren_count, t_env *env);
+t_dfa_state	update_state(char c, t_dfa_state current_state);
+bool		unmatched_parenthesis(t_env *env);
+bool		check_unmatched(t_dfa_state state,
+				int open_paren_count, t_env *env);
 
 bool	quotes_paren_match(char *input, t_env *env)
 {
-	size_t			i;
-	t_lexer_state	state;
-	int				open_paren_count;
+	size_t		i;
+	t_dfa_state	state;
+	int			open_paren_count;
 
 	i = -1;
 	state = TEXT;

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -19,7 +19,7 @@ static void	push_redir(t_cmd *self, t_redir *redir)
 	self->redirs->push(self->redirs, redir);
 }
 
-static void	set_argv(t_cmd *self, char **argv)
+static void	set_argv(t_cmd *self, t_darray *argv)
 {
 	self->argv = argv;
 }

--- a/src/error_msg.c
+++ b/src/error_msg.c
@@ -31,7 +31,7 @@ static bool	unmatched_quotes(t_env *env)
 	return (false);
 }
 
-bool	check_unmatched(t_lexer_state state, int open_paren_count, t_env *env)
+bool	check_unmatched(t_dfa_state state, int open_paren_count, t_env *env)
 {
 	if (state != TEXT)
 		return (unmatched_quotes(env));

--- a/src/exec_pipe_2.c
+++ b/src/exec_pipe_2.c
@@ -73,6 +73,7 @@ void	exec_child(t_btree *node, int in_fd, int out_fd, t_env *env)
 	t_token	*token;
 	t_cmd	*cmd;
 	int		exit_code;
+	char	**argv;
 
 	manage_dup(in_fd, out_fd, env->gc);
 	token = node->value;
@@ -80,8 +81,11 @@ void	exec_child(t_btree *node, int in_fd, int out_fd, t_env *env)
 	{
 		cmd = token->cmd;
 		if (apply_redirs(cmd, env))
-			exit_code = gc_execvp(cmd->argv[0], cmd->argv,
+		{
+			argv = (char **)cmd->argv->to_arr(cmd->argv);
+			exit_code = gc_execvp(argv[0], argv,
 					(char **)env->envp->to_arr(env->envp), env->gc);
+		}
 		else
 			exit_code = env->exit_code;
 		env->gc->clean(env->gc);

--- a/src/exec_pipe_2.c
+++ b/src/exec_pipe_2.c
@@ -82,6 +82,7 @@ void	exec_child(t_btree *node, int in_fd, int out_fd, t_env *env)
 		cmd = token->cmd;
 		if (apply_redirs(cmd, env))
 		{
+			expand_cmd(cmd, env);
 			argv = (char **)cmd->argv->to_arr(cmd->argv);
 			exit_code = gc_execvp(argv[0], argv,
 					(char **)env->envp->to_arr(env->envp), env->gc);

--- a/src/executor.c
+++ b/src/executor.c
@@ -34,6 +34,7 @@ static void	exec_builtin_cmd(t_cmd *cmd, t_env *env)
 	saved_stdout = dup(STDOUT_FILENO);
 	if (apply_redirs(cmd, env))
 	{
+		expand_cmd(cmd, env);
 		argv = (char **)cmd->argv->to_arr(cmd->argv);
 		exec_builtins(argv[0], argv, env);
 	}
@@ -48,8 +49,9 @@ static void	exec_fork_child(t_cmd *cmd, t_env *env)
 	int		status;
 	char	**argv;
 
-	if(apply_redirs(cmd, env))
+	if (apply_redirs(cmd, env))
 	{
+		expand_cmd(cmd, env);
 		argv = (char **)cmd->argv->to_arr(cmd->argv);
 		status = gc_execvp(argv[0], argv,
 				(char **)env->envp->to_arr(env->envp), env->gc);

--- a/src/executor.c
+++ b/src/executor.c
@@ -26,13 +26,17 @@ bool		strs_eq(void *s1, void *s2);
 
 static void	exec_builtin_cmd(t_cmd *cmd, t_env *env)
 {
-	int	saved_stdin;
-	int	saved_stdout;
+	int		saved_stdin;
+	int		saved_stdout;
+	char	**argv;
 
 	saved_stdin = dup(STDIN_FILENO);
 	saved_stdout = dup(STDOUT_FILENO);
 	if (apply_redirs(cmd, env))
-		exec_builtins(cmd->argv[0], cmd->argv, env);
+	{
+		argv = (char **)cmd->argv->to_arr(cmd->argv);
+		exec_builtins(argv[0], argv, env);
+	}
 	dup2(saved_stdin, STDIN_FILENO);
 	dup2(saved_stdout, STDOUT_FILENO);
 	close(saved_stdin);
@@ -41,11 +45,15 @@ static void	exec_builtin_cmd(t_cmd *cmd, t_env *env)
 
 static void	exec_fork_child(t_cmd *cmd, t_env *env)
 {
-	int	status;
+	int		status;
+	char	**argv;
 
 	if(apply_redirs(cmd, env))
-		status = gc_execvp(cmd->argv[0], cmd->argv,
+	{
+		argv = (char **)cmd->argv->to_arr(cmd->argv);
+		status = gc_execvp(argv[0], argv,
 				(char **)env->envp->to_arr(env->envp), env->gc);
+	}
 	else
 		status = env->exit_code;
 	env->gc->clean(env->gc);
@@ -57,7 +65,7 @@ static void	exec_cmd(t_cmd *cmd, t_env *env)
 	pid_t	pid;
 	int		status;
 
-	if (env->builtins->any(env->builtins, strs_eq, cmd->argv[0]))
+	if (env->builtins->any(env->builtins, strs_eq, cmd->argv->peek_i(cmd->argv, 0)))
 	{
 		exec_builtin_cmd(cmd, env);
 		return ;

--- a/src/expander.c
+++ b/src/expander.c
@@ -1,0 +1,96 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   expander.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: weizhang <weiqi.zhang_arthur@yahoo.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2026/05/10 18:48:47 by weizhang          #+#    #+#             */
+/*   Updated: 2026/05/10 19:07:47 by weizhang         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <stddef.h>
+#include "datastructures.h"
+#include "minishell.h"
+
+void	*gc_strjoin_wrap(void *s1, void *s2, t_gc *gc);
+
+char	*expand_arg(char *arg, t_env *env)
+{
+	t_lexer_state	state;
+	t_darray		*fragments;
+	size_t			i;
+	size_t			start;
+
+	fragments = init_darray(env->gc);
+	state = TEXT;
+	i = 0;
+	start = 0;
+	while (arg[i])
+	{
+		if (state == TEXT)
+		{
+			if (arg[i] == '\'')
+			{
+				state = SINGLE;
+				fragments->push(fragments, gc_substr(arg, start, i - start, env->gc));
+				start = i + 1;
+			}
+			else if (arg[i] == '"')
+			{
+				state = DOUBLE;
+				fragments->push(fragments, gc_substr(arg, start, i - start, env->gc));
+				start = i + 1;
+			}
+		}
+		else if (state == SINGLE)
+		{
+			if (arg[i] == '\'')
+			{
+				state = TEXT;
+				fragments->push(fragments, gc_substr(arg, start, i - start, env->gc));
+				start = i + 1;
+			}
+		}
+		else if (state == DOUBLE)
+		{
+			if (arg[i] == '"')
+			{
+				state = TEXT;
+				fragments->push(fragments, gc_substr(arg, start, i - start, env->gc));
+				start = i + 1;
+			}
+		}
+		i++;
+	}
+	fragments->push(fragments, gc_substr(arg, start, i - start, env->gc));
+	return (fragments->reduce(fragments, gc_strjoin_wrap, ""));
+}
+
+void	expand_cmd(char **argv, t_env *env)
+{
+	size_t	i;
+
+	i = 0;
+	while (argv[i])
+	{
+		argv[i] = expand_arg(argv[i], env);
+		i++;
+	}
+}
+
+void	expand_ast(t_btree *ast, t_env *env)
+{
+	t_token	*token;
+	token = ast->value;
+	if (token->type == CMD)
+		expand_cmd(token->cmd->argv, env);
+	else if (token->type == SUBSHELL)
+		expand_ast(ast->left, env);
+	else
+	{
+		expand_ast(ast->left, env);
+		expand_ast(ast->right, env);
+	}
+}

--- a/src/expander.c
+++ b/src/expander.c
@@ -18,10 +18,10 @@ void	*gc_strjoin_wrap(void *s1, void *s2, t_gc *gc);
 
 char	*expand_arg(char *arg, t_env *env)
 {
-	t_lexer_state	state;
-	t_darray		*fragments;
-	size_t			i;
-	size_t			start;
+	t_dfa_state	state;
+	t_darray	*fragments;
+	size_t		i;
+	size_t		start;
 
 	fragments = init_darray(env->gc);
 	state = TEXT;

--- a/src/expander.c
+++ b/src/expander.c
@@ -149,19 +149,3 @@ void	expand_cmd(t_cmd *cmd, t_env *env)
 		i++;
 	}
 }
-
-void	expand_ast(t_btree *ast, t_env *env)
-{
-	t_token	*token;
-
-	token = ast->value;
-	if (token->type == CMD)
-		expand_cmd(token->cmd, env);
-	else if (token->type == SUBSHELL)
-		expand_ast(ast->left, env);
-	else
-	{
-		expand_ast(ast->left, env);
-		expand_ast(ast->right, env);
-	}
-}

--- a/src/expander.c
+++ b/src/expander.c
@@ -12,6 +12,7 @@
 
 #include <stddef.h>
 #include "datastructures.h"
+#include "libft.h"
 #include "minishell.h"
 
 void	*gc_strjoin_wrap(void *s1, void *s2, t_gc *gc);
@@ -19,6 +20,7 @@ void	*gc_strjoin_wrap(void *s1, void *s2, t_gc *gc);
 char	*expand_arg(char *arg, t_env *env)
 {
 	t_dfa_state	state;
+	t_dfa_state	previous;
 	t_darray	*fragments;
 	size_t		i;
 	size_t		start;
@@ -43,6 +45,13 @@ char	*expand_arg(char *arg, t_env *env)
 				fragments->push(fragments, gc_substr(arg, start, i - start, env->gc));
 				start = i + 1;
 			}
+			else if (arg[i] == '$')
+			{
+				previous = state;
+				state = DOLLAR;
+				fragments->push(fragments, gc_substr(arg, start, i - start, env->gc));
+				start = i + 1;
+			}
 		}
 		else if (state == SINGLE)
 		{
@@ -59,6 +68,28 @@ char	*expand_arg(char *arg, t_env *env)
 			{
 				state = TEXT;
 				fragments->push(fragments, gc_substr(arg, start, i - start, env->gc));
+				start = i + 1;
+			}
+			else if (arg[i] == '$')
+			{
+				previous = state;
+				state = DOLLAR;
+				fragments->push(fragments, gc_substr(arg, start, i - start, env->gc));
+				start = i + 1;
+			}
+		}
+		else if (state == DOLLAR)
+		{
+			if (arg[i] == '?')
+			{
+				fragments->push(fragments, gc_itoa(env->exit_code, env->gc));
+				state = previous;
+				start = i + 1;
+			}
+			else
+			{
+				fragments->push(fragments, "$");
+				state = previous;
 				start = i + 1;
 			}
 		}

--- a/src/expander.c
+++ b/src/expander.c
@@ -68,14 +68,15 @@ char	*expand_arg(char *arg, t_env *env)
 	return (fragments->reduce(fragments, gc_strjoin_wrap, ""));
 }
 
-void	expand_cmd(t_darray *argv, t_env *env)
+void	expand_cmd(t_cmd *cmd, t_env *env)
 {
 	size_t	i;
 
 	i = 0;
-	while (i < argv->len)
+	while (i < cmd->argv->len)
 	{
-		argv->set(argv, i, expand_arg(argv->peek_i(argv, i), env));
+		cmd->argv->set(cmd->argv, i,
+				expand_arg(cmd->argv->peek_i(cmd->argv, i), env));
 		i++;
 	}
 }
@@ -86,7 +87,7 @@ void	expand_ast(t_btree *ast, t_env *env)
 
 	token = ast->value;
 	if (token->type == CMD)
-		expand_cmd(token->cmd->argv, env);
+		expand_cmd(token->cmd, env);
 	else if (token->type == SUBSHELL)
 		expand_ast(ast->left, env);
 	else

--- a/src/expander.c
+++ b/src/expander.c
@@ -70,13 +70,21 @@ char	*expand_arg(char *arg, t_env *env)
 
 void	expand_cmd(t_cmd *cmd, t_env *env)
 {
+	t_redir	*redir;
 	size_t	i;
 
 	i = 0;
 	while (i < cmd->argv->len)
 	{
 		cmd->argv->set(cmd->argv, i,
-				expand_arg(cmd->argv->peek_i(cmd->argv, i), env));
+			expand_arg(cmd->argv->peek_i(cmd->argv, i), env));
+		i++;
+	}
+	i = 0;
+	while (i < cmd->redirs->len)
+	{
+		redir = cmd->redirs->peek_i(cmd->redirs, i);
+		redir->set_filename(redir, expand_arg(redir->filename, env));
 		i++;
 	}
 }

--- a/src/expander.c
+++ b/src/expander.c
@@ -68,14 +68,14 @@ char	*expand_arg(char *arg, t_env *env)
 	return (fragments->reduce(fragments, gc_strjoin_wrap, ""));
 }
 
-void	expand_cmd(char **argv, t_env *env)
+void	expand_cmd(t_darray *argv, t_env *env)
 {
 	size_t	i;
 
 	i = 0;
-	while (argv[i])
+	while (i < argv->len)
 	{
-		argv[i] = expand_arg(argv[i], env);
+		argv->set(argv, i, expand_arg(argv->peek_i(argv, i), env));
 		i++;
 	}
 }
@@ -83,6 +83,7 @@ void	expand_cmd(char **argv, t_env *env)
 void	expand_ast(t_btree *ast, t_env *env)
 {
 	t_token	*token;
+
 	token = ast->value;
 	if (token->type == CMD)
 		expand_cmd(token->cmd->argv, env);

--- a/src/expander.c
+++ b/src/expander.c
@@ -16,6 +16,18 @@
 #include "minishell.h"
 
 void	*gc_strjoin_wrap(void *s1, void *s2, t_gc *gc);
+bool	startswith(void *s, void *ref);
+
+char	*find_var(char *var, t_env *env)
+{
+	size_t	var_len;
+
+	var_len = ft_strlen(var);
+	var = env->envp->find(env->envp, startswith, gc_strjoin(var, "=", env->gc));
+	if (!var)
+		return ("");
+	return (gc_strdup(&var[var_len + 1], env->gc));
+}
 
 char	*expand_arg(char *arg, t_env *env)
 {
@@ -86,16 +98,34 @@ char	*expand_arg(char *arg, t_env *env)
 				state = previous;
 				start = i + 1;
 			}
+			else if (ft_isalpha(arg[i]) || arg[i] == '_')
+				state = ALPHA;
 			else
 			{
 				fragments->push(fragments, "$");
 				state = previous;
-				start = i + 1;
+				start = i;
+				continue ;
+			}
+		}
+		else if (state == ALPHA)
+		{
+			if (!ft_isalnum(arg[i]))
+			{
+				fragments->push(fragments, find_var(gc_substr(arg, start, i - start, env->gc), env));
+				state = previous;
+				start = i;
+				continue ;
 			}
 		}
 		i++;
 	}
-	fragments->push(fragments, gc_substr(arg, start, i - start, env->gc));
+	if (state == DOLLAR)
+		fragments->push(fragments, "$");
+	else if (state == ALPHA)
+		fragments->push(fragments, find_var(gc_substr(arg, start, i - start, env->gc), env));
+	else
+		fragments->push(fragments, gc_substr(arg, start, i - start, env->gc));
 	return (fragments->reduce(fragments, gc_strjoin_wrap, ""));
 }
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -16,7 +16,7 @@
 #include "datastructures.h"
 #include "minishell.h"
 
-t_lexer_state	update_state(char c, t_lexer_state current_state)
+t_dfa_state	update_state(char c, t_dfa_state current_state)
 {
 	if (current_state == TEXT)
 	{
@@ -81,8 +81,8 @@ static size_t	lookup(t_darray *tokens, char *cmd, size_t start, size_t i)
 
 t_darray	*tokenize(char *cmd, t_gc *gc)
 {
-	t_darray		*tokens;
-	t_lexer_state	state;
+	t_darray	*tokens;
+	t_dfa_state	state;
 	size_t			i;
 	size_t			start;
 

--- a/src/lexer_postprocess.c
+++ b/src/lexer_postprocess.c
@@ -82,7 +82,7 @@ static size_t	collect_argv(t_darray *operands, size_t i,
 		else
 			break ;
 	}
-	cmd->set_argv(cmd, (char **)argv->to_arr(argv));
+	cmd->set_argv(cmd, argv);
 	cmds->push(cmds, init_cmd_token(cmd, cmds->gc));
 	return (i);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -36,6 +36,7 @@ int	main(void)
 		ast = parse(input, env);
 		if (!ast)
 			continue ;
+		expand_ast(ast, env);
 		execute(ast, env);
 	}
 	printf("exit\n");

--- a/src/main.c
+++ b/src/main.c
@@ -36,7 +36,6 @@ int	main(void)
 		ast = parse(input, env);
 		if (!ast)
 			continue ;
-		expand_ast(ast, env);
 		execute(ast, env);
 	}
 	printf("exit\n");

--- a/src/redir.c
+++ b/src/redir.c
@@ -6,7 +6,7 @@
 /*   By: weizhang <weiqi.zhang_arthur@yahoo.com>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2026/04/02 21:00:01 by weizhang          #+#    #+#             */
-/*   Updated: 2026/04/02 21:03:29 by weizhang         ###   ########.fr       */
+/*   Updated: 2026/05/11 00:21:37 by weizhang         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -111,6 +111,11 @@ bool	apply_redirs(t_cmd *cmd, t_env *env)
 	return (flag);
 }
 
+static void	set_filename(t_redir *self, char *filename)
+{
+	self->filename = filename;
+}
+
 t_redir	*init_redir(t_redir_type redir_type, char *filename, t_gc *gc)
 {
 	t_redir	*redir;
@@ -118,6 +123,7 @@ t_redir	*init_redir(t_redir_type redir_type, char *filename, t_gc *gc)
 	redir = gc_malloc(sizeof(t_redir), gc);
 	redir->redir_type = redir_type;
 	redir->filename = filename;
+	redir->set_filename = set_filename;
 	redir->gc = gc;
 	return (redir);
 }

--- a/src/token.c
+++ b/src/token.c
@@ -42,7 +42,7 @@ static void	match_binding_power(t_token *token)
 static void	repr(t_token *self)
 {
 	if (self->type == CMD)
-		repr_strs(self->cmd->argv);
+		repr_strs((char **)self->cmd->argv->to_arr(self->cmd->argv));
 	else
 		ft_printf("\"%s\"", self->value);
 }

--- a/src/utils/str_utils.c
+++ b/src/utils/str_utils.c
@@ -13,6 +13,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include "gc_libft.h"
 #include "libft.h"
 
 bool	strs_eq(void *s1, void *s2)
@@ -70,4 +71,9 @@ bool	int64_overflow(char *n)
 		i++;
 	}
 	return (false);
+}
+
+void	*gc_strjoin_wrap(void *s1, void *s2, t_gc *gc)
+{
+	return (gc_strjoin(s1, s2, gc));
 }

--- a/tests/test.norminette
+++ b/tests/test.norminette
@@ -446,17 +446,88 @@ static void	test_error_handling(t_env *env)
 	ft_printf("==========ALL TESTS PASSED==========\n\n");
 }
 
-static void	test_expander_case(char *arg, t_env *env)
+static void	test_expander_case(char *arg, char *expected, t_env *env)
 {
-	ft_printf("Before: %s\n", arg);
-	ft_printf("Expanded: %s\n\n", expand_arg(arg, env));
+	char	*result;
+
+	result = expand_arg(arg, env);
+	ft_printf("Before expand: %s\n", arg);
+	ft_printf("After expand: %s\n", result);
+	ft_printf("Expected: %s\n\n", expected);
+	assert(strcmp(result, expected) == 0);
 }
 
 static void	test_expander(t_env *env)
 {
 	ft_printf("==========TEST_EXPANDER==========\n\n");
 
-	test_expander_case("\"hello\"", env);
+	// quote removal
+	test_expander_case("hello", "hello", env);
+	test_expander_case("\"hello\"", "hello", env);
+	test_expander_case("'hello'", "hello", env);
+	test_expander_case("\"hello\"world", "helloworld", env);
+	test_expander_case("'hello'world", "helloworld", env);
+	test_expander_case("hel'lo'world", "helloworld", env);
+	test_expander_case("hel\"lo\"world", "helloworld", env);
+	test_expander_case("''", "", env);
+	test_expander_case("\"\"", "", env);
+	test_expander_case("'hello'\"world\"", "helloworld", env);
+
+	// single quotes block expansion
+	test_expander_case("'$HOME'", "$HOME", env);
+	test_expander_case("'$?'", "$?", env);
+	test_expander_case("'$NONEXIST'", "$NONEXIST", env);
+
+	// $? expansion
+	env->exit_code = 0;
+	test_expander_case("$?", "0", env);
+	env->exit_code = 42;
+	test_expander_case("$?", "42", env);
+	test_expander_case("\"$?\"", "42", env);
+	test_expander_case("exit:$?", "exit:42", env);
+	test_expander_case("\"exit:$?\"", "exit:42", env);
+	env->exit_code = 130;
+	test_expander_case("$?$?", "130130", env);
+	env->exit_code = 0;
+
+	// variable expansion
+	env->envp->push(env->envp, "FOO=bar");
+	env->envp->push(env->envp, "GREETING=hello world");
+	env->envp->push(env->envp, "EMPTY=");
+	env->envp->push(env->envp, "A=1");
+	env->envp->push(env->envp, "AB=2");
+
+	test_expander_case("$FOO", "bar", env);
+	test_expander_case("\"$FOO\"", "bar", env);
+	test_expander_case("$GREETING", "hello world", env);
+	test_expander_case("$EMPTY", "", env);
+	test_expander_case("$NONEXIST", "", env);
+
+	// variable with surrounding text
+	test_expander_case("pre$FOO", "prebar", env);
+	test_expander_case("$FOOpost", "", env);
+	test_expander_case("pre$FOO.post", "prebar.post", env);
+	test_expander_case("\"pre$FOO\"", "prebar", env);
+	test_expander_case("\"$FOO.post\"", "bar.post", env);
+
+	// bare dollar sign
+	test_expander_case("$", "$", env);
+	test_expander_case("hello$", "hello$", env);
+	test_expander_case("\"$\"", "$", env);
+	test_expander_case("\"hello$\"", "hello$", env);
+
+	// $ followed by non-alpha non-underscore
+	test_expander_case("$.", "$.", env);
+	test_expander_case("$-x", "$-x", env);
+
+	// mixed quotes and expansion
+	test_expander_case("'$FOO'\"$FOO\"", "$FOObar", env);
+	test_expander_case("\"$FOO\"'$FOO'", "bar$FOO", env);
+	test_expander_case("pre'mid'\"$FOO\"end", "premidbarend", env);
+
+	// multiple variables
+	test_expander_case("$A$AB", "12", env);
+	test_expander_case("$A-$AB", "1-2", env);
 
 	ft_printf("==========ALL TESTS PASSED==========\n\n");
 }

--- a/tests/test.norminette
+++ b/tests/test.norminette
@@ -23,6 +23,7 @@ void		repr_node(void *ptr);
 bool		quotes_paren_match(char *input, t_env *env);
 t_darray	*tokenize(char *cmd, t_gc *gc);
 t_darray	*postprocess(t_darray *operands, t_env *env);
+char		*expand_arg(char *arg, t_env *env);
 
 static void	test_t_token_case(t_gc *gc, char *s, char *expected_value,
 		t_token_type expected_type)
@@ -445,6 +446,21 @@ static void	test_error_handling(t_env *env)
 	ft_printf("==========ALL TESTS PASSED==========\n\n");
 }
 
+static void	test_expander_case(char *arg, t_env *env)
+{
+	ft_printf("Before: %s\n", arg);
+	ft_printf("Expanded: %s\n\n", expand_arg(arg, env));
+}
+
+static void	test_expander(t_env *env)
+{
+	ft_printf("==========TEST_EXPANDER==========\n\n");
+
+	test_expander_case("\"hello\"", env);
+
+	ft_printf("==========ALL TESTS PASSED==========\n\n");
+}
+
 int main(void)
 {
 	t_gc	*gc;
@@ -460,5 +476,6 @@ int main(void)
 	test_flatten(env);
 	test_exec(env);
 	test_error_handling(env);
+	test_expander(env);
 	gc->clean(gc);
 }


### PR DESCRIPTION
## Summary

This PR introduces environment variable expansion (`$VAR`, `$?`)

### Expander

- Implement a DFA-based expander (`expand_arg`) that processes `TEXT`, `SINGLE`, `DOUBLE`, `DOLLAR`, and `ALPHA` states
- Expand `$VAR` to its value from `envp`, `$?` to the last exit code
- Single-quoted strings suppress expansion; double-quoted strings allow `$` expansion
- Expansion applies to both command argv and redirection filenames

### Refactors

- Rename `t_lexer_state` to `t_dfa_state`, add `DOLLAR` and `ALPHA` states
- Replace `char **argv` in `t_cmd` with `t_darray` for dynamic mutation during expansion

### Data Structure Extensions

- `darray`: add `set()` method

### Tests

- Add expander tests covering quote removal, variable expansion, `$?`, and mixed cases